### PR TITLE
Use preformatted text in parsed log

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserParser.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserParser.java
@@ -37,9 +37,11 @@ public class LogParserParser  {
 	final private LogParserDisplayConsts displayConstants = new LogParserDisplayConsts();
 
 	final private VirtualChannel channel;
+	final private boolean preformattedHtml;
 
 	
-	public LogParserParser(final String parsingRulesPath, final VirtualChannel channel) throws IOException {
+	public LogParserParser(final String parsingRulesPath, final boolean preformattedHtml, 
+				final VirtualChannel channel) throws IOException {
 		
 		// init logger
 		final Logger logger = Logger.getLogger(getClass().getName());
@@ -55,6 +57,7 @@ public class LogParserParser  {
 		this.compiledPatternsPlusError = LogParserUtils.compilePatterns(this.parsingRulesArray,logger);
 		this.compiledPatterns = this.compiledPatternsPlusError.getCompiledPatterns() ;
 		
+		this.preformattedHtml = preformattedHtml;
 		this.channel = channel;
 	} 
 	
@@ -107,7 +110,8 @@ public class LogParserParser  {
 		LogParserWriter.writeHeaderTemplateToAllLinkFiles(writers,sectionCounter); // This enters a line which will later be replaced by the actual header and count for this header
 		headerForSection.add(shortLink);
 		writer.write(LogParserConsts.getHtmlOpeningTags());
-        
+		if (this.preformattedHtml)
+			writer.write("<pre>");        
 		// Read bulks of lines , parse 
   	  	final int linesInLog = LogParserUtils.countLines(logFileLocation);
 		parseLogBody(build,writer,filePath,logFileLocation,linesInLog,logger);
@@ -116,6 +120,8 @@ public class LogParserParser  {
 		//writeLogBody();
 		
 		// Close html footer
+		if (this.preformattedHtml)
+			writer.write("</pre>");        
 		writer.write(LogParserConsts.getHtmlClosingTags());
         writer.close();  // Close to unlock and flush to disk.
 
@@ -192,7 +198,8 @@ public class LogParserParser  {
 			parsedLine = parsedLineColoredAndMarked;
 		}
 		final StringBuffer result = new StringBuffer(parsedLine);
-		result.append("<br/>\n");
+		if (!preformattedHtml)
+			result.append("<br/>\n");
 		return result.toString() ;
 	}
 	

--- a/src/main/java/hudson/plugins/logparser/LogParserPublisher.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserPublisher.java
@@ -28,8 +28,7 @@ public class LogParserPublisher extends Recorder implements Serializable {
     public final String parsingRulesPath;
 
     @DataBoundConstructor
-    public LogParserPublisher(final boolean unstableOnWarning, final boolean failBuildOnError, final boolean showGraphs,
-                              final String parsingRulesPath) {
+    public LogParserPublisher(final boolean unstableOnWarning, final boolean failBuildOnError, final boolean showGraphs, final String parsingRulesPath) {
         this.unstableOnWarning = unstableOnWarning;
         this.failBuildOnError = failBuildOnError;
         this.showGraphs = showGraphs;
@@ -45,7 +44,8 @@ public class LogParserPublisher extends Recorder implements Serializable {
         LogParserResult result = new LogParserResult();
         try {
             // Create a parser with the parsing rules as configured : colors, regular expressions, etc.
-            final LogParserParser parser = new LogParserParser(this.parsingRulesPath,launcher.getChannel());
+            boolean preformattedHtml = ! ((DescriptorImpl)getDescriptor()).getLegacyFormatting();
+            final LogParserParser parser = new LogParserParser(this.parsingRulesPath, preformattedHtml, launcher.getChannel());
             // Parse the build's log according to these rules and get the result
             result = parser.parseLog(build);
 
@@ -82,6 +82,7 @@ public class LogParserPublisher extends Recorder implements Serializable {
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
         private volatile ParserRuleFile[] parsingRulesGlobal = new ParserRuleFile[0];
+	private boolean useLegacyFormatting = false;
 
         private DescriptorImpl() {
             super(LogParserPublisher.class);
@@ -103,11 +104,16 @@ public class LogParserPublisher extends Recorder implements Serializable {
         public  ParserRuleFile[] getParsingRulesGlobal() {
             return parsingRulesGlobal;
         }
+	public boolean getLegacyFormatting() {
+            return useLegacyFormatting;
+        }
 
         @Override
         public boolean configure(final StaplerRequest req, final JSONObject json) throws FormException {
             parsingRulesGlobal = req.bindParametersToList(ParserRuleFile.class, "log-parser.")
                     .toArray(new ParserRuleFile[0]);
+       //     useLegacyFormatting = json.getBoolean("useLegacyFormatting");
+            useLegacyFormatting = json.getJSONObject("log-parser").getBoolean("useLegacyFormatting");
             save();
             return true;
         }

--- a/src/main/resources/hudson/plugins/logparser/LogParserPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/logparser/LogParserPublisher/config.jelly
@@ -9,9 +9,8 @@
     	<f:entry title="Show log parser graphs" help="/plugin/log-parser/parser_graphs.html">
     		<f:checkbox name="log-parser.showGraphs" checked="${instance.showGraphs}"/>
     	</f:entry>
-
     	
-   		<f:entry title="Select Parsing Rules" field="currentRulePath" help="/plugin/log-parser/parse_rule_choice.html">
+   	<f:entry title="Select Parsing Rules" field="currentRulePath" help="/plugin/log-parser/parse_rule_choice.html">
         	<select name="log-parser.parsingRulesPath">
         	
 	            <j:forEach var="i" items="${descriptor.parsingRulesGlobal}">

--- a/src/main/resources/hudson/plugins/logparser/LogParserPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/logparser/LogParserPublisher/global.jelly
@@ -1,5 +1,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="Console Output Parsing">
+  <f:section title="Console Output Parsing" name="log-parser">
 
 
     <f:entry title="Parsing Rules" help="/plugin/log-parser/global_config_help.html">
@@ -26,6 +26,11 @@
       
     </f:entry>
   
+    <f:advanced>
+      <f:entry title="Use Legacy Formatting (variable width font)" help="/plugin/log-parser/global_legacy_formatting.html">
+        <f:checkbox name="useLegacyFormatting" checked="${descriptor.getLegacyFormatting()}"/>
+      </f:entry>
+    </f:advanced>
 
   </f:section>
 </j:jelly>

--- a/src/main/webapp/global_legacy_formatting.html
+++ b/src/main/webapp/global_legacy_formatting.html
@@ -1,0 +1,1 @@
+Use variable width font and HTML spacing in log view. This is the old default style.


### PR DESCRIPTION
Wrap log in pre-tags and remove inserting forced linebreaks.
Fixed width font and retaining the spacing will increase readability.
Add global option to fall back to the legacy style log formatting.

Hi John,

Here is a new patch that has been modified according to your feedback. I'm glad to see that we agree on the idea that the preformatted style should be the default. And now there is even a global option to fall back to the legacy style.

Cheers,
Jukka
