### PR TITLE
chrome fix for anchors

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserParser.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserParser.java
@@ -272,9 +272,9 @@ public class LogParserParser {
         linkWriter.newLine(); // Write system dependent end of line.
 
         // Mark the line
-        final StringBuffer markedLine = new StringBuffer("<a name=\"");
+        final StringBuffer markedLine = new StringBuffer("<p><a name=\"");
         markedLine.append(marker);
-        markedLine.append("\"></a>");
+        markedLine.append("\"></a></p>");
         markedLine.append(line);
 
         // Handle case where we are entering a new section


### PR DESCRIPTION
I noticed that anchors aren't working for Chrome.  Surrounding the anchor with a paragraph element seems to give Chrome the necessary context to honor the anchor.  
