### PR TITLE
Fixed error where the configuration of project/global rules didn't stick...

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserPublisher.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserPublisher.java
@@ -190,10 +190,10 @@ public class LogParserPublisher extends Recorder implements Serializable {
             if (useProjectRuleJSON != null) {
                 configuredUseProjectRule = useProjectRuleJSON.getBoolean("value");
 
-                if (!configuredUseProjectRule && json.containsKey("parsingRulesPath")) {
-                    configuredParsingRulesPath = json.getString("parsingRulesPath");
-                } else if (configuredUseProjectRule && json.containsKey("projectRulePath")) {
-                    configuredProjectRulePath = json.getString("projectRulePath");
+                if (!configuredUseProjectRule && useProjectRuleJSON.containsKey("parsingRulesPath")) {
+                    configuredParsingRulesPath = useProjectRuleJSON.getString("parsingRulesPath");
+                } else if (configuredUseProjectRule && useProjectRuleJSON.containsKey("projectRulePath")) {
+                    configuredProjectRulePath = useProjectRuleJSON.getString("projectRulePath");
                 }
             }
             return new LogParserPublisher(json.getBoolean("unstableOnWarning"),


### PR DESCRIPTION
.... The problem was caused due to looking for a JSON key on the JSON top level instead of in the sub object.

For example configuring to use a global rule for a job did not work. Using the JSON:

{"unstableOnWarning":false,"failBuildOnError":false,"showGraphs":true,"useProjectRule":{"value":"false","parsingRulesPath":"/usr/share/jenkins/log_parser_rules/erlang_dialyzer.rules"},"stapler-class":"hudson.plugins.logparser.LogParserPublisher","kind":"hudson.plugins.logparser.LogParserPublisher"}

The old code looked at the top-level JSON for a "parsingRulesPath" and did not find any. This change makes sure 
that to look for the key in 

{"value":"false","parsingRulesPath":"/usr/share/jenkins/log_parser_rules/erlang_dialyzer.rules"}
