### PR TITLE
Fix failing test

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
@@ -40,7 +40,7 @@ public class LogParserWorkflowTest {
         job.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  def mvnHome = tool '" + mavenInstallation.getName() + "'\n"
-                        + "  sh \"export M2_HOME=${mvnHome};${mvnHome}/bin/mvn clean install\"\n"
+                        + "  sh \"M2_HOME=${mvnHome};${mvnHome}/bin/mvn clean install\"\n"
                         + "  step([$class: 'LogParserPublisher', projectRulePath: 'logparser-rules.txt', useProjectRule: true])\n"
                         + "}\n", true)
         );

--- a/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
@@ -40,7 +40,7 @@ public class LogParserWorkflowTest {
         job.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  def mvnHome = tool '" + mavenInstallation.getName() + "'\n"
-                        + "  sh \"${mvnHome}/bin/mvn clean install\"\n"
+                        + "  sh \"export M2_HOME=${mvnHome};${mvnHome}/bin/mvn clean install\"\n"
                         + "  step([$class: 'LogParserPublisher', projectRulePath: 'logparser-rules.txt', useProjectRule: true])\n"
                         + "}\n", true)
         );


### PR DESCRIPTION
The  LogParserPublisherWorkflowStep test will fail because of the M2_HOME is not correctly set (it may work on some machines but in order to make it work on all machines, we need to set the M2_HOME).
