### PR TITLE
Add support for parsing to debug tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
       <version>1.7.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.9.5</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,6 @@
       <version>1.7.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/hudson/plugins/logparser/LogParserAction.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserAction.java
@@ -142,6 +142,8 @@ public class LogParserAction implements Action {
                     new ChartUtil.NumberOnlyBuildLabel(a.getOwner()));
             dsb.add(a.result.getTotalInfos(), "infos",
                     new ChartUtil.NumberOnlyBuildLabel(a.getOwner()));
+            dsb.add(a.result.getTotalDebugs(), "debugs",
+                    new ChartUtil.NumberOnlyBuildLabel(a.getOwner()));
         }
         return dsb.build();
     }
@@ -211,6 +213,8 @@ public class LogParserAction implements Action {
                     return "Errors: " + result.getTotalErrors();
                 case 1:
                     return "Warnings: " + result.getTotalWarnings();
+                case 2:
+                    return "Debugs: " + result.getTotalDebugs();
                 default:
                     return "Infos: " + result.getTotalInfos();
                 }
@@ -220,6 +224,7 @@ public class LogParserAction implements Action {
         ar.setSeriesPaint(0, ColorPalette.RED);    // error
         ar.setSeriesPaint(1, ColorPalette.BLUE);   // info
         ar.setSeriesPaint(2, ColorPalette.YELLOW); // warning
+        ar.setSeriesPaint(3, ColorPalette.BLUE);   // debug
 
         // crop extra space around the graph
         plot.setInsets(new RectangleInsets(0, 0, 0, 5.0));

--- a/src/main/java/hudson/plugins/logparser/LogParserConsts.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserConsts.java
@@ -10,6 +10,7 @@ public class LogParserConsts {
     public static final String ERROR = "ERROR";
     public static final String WARNING = "WARNING";
     public static final String INFO = "INFO";
+    public static final String DEBUG = "debug";
     public static final String NONE = "NONE";
     public static final String START = "START"; // marks a beginning of a section
     public static final String DEFAULT = NONE;
@@ -18,9 +19,9 @@ public class LogParserConsts {
     public static final String CANNOT_PARSE = "log-parser plugin ERROR: Cannot parse log ";
     public static final String NOT_INT = " is not an integer - using default";
 
-    public static final List<String> LEGAL_STATUS = Arrays.asList(ERROR, WARNING, INFO, NONE, START);
-    public static final List<String> STATUSES_WITH_LINK_FILES = Arrays.asList(ERROR, WARNING, INFO);
-    public static final List<String> STATUSES_WITH_SECTIONS_IN_LINK_FILES = Arrays.asList(ERROR, WARNING);
+    public static final List<String> LEGAL_STATUS = Arrays.asList(ERROR, WARNING, INFO, DEBUG, NONE, START);
+    public static final List<String> STATUSES_WITH_LINK_FILES = Arrays.asList(ERROR, WARNING, INFO, DEBUG);
+    public static final List<String> STATUSES_WITH_SECTIONS_IN_LINK_FILES = Arrays.asList(ERROR, WARNING, DEBUG);
 
     public static String getHtmlOpeningTags() {
         final String hudsonRoot = Jenkins.getActiveInstance().getRootUrl();

--- a/src/main/java/hudson/plugins/logparser/LogParserConsts.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserConsts.java
@@ -10,7 +10,7 @@ public class LogParserConsts {
     public static final String ERROR = "ERROR";
     public static final String WARNING = "WARNING";
     public static final String INFO = "INFO";
-    public static final String DEBUG = "debug";
+    public static final String DEBUG = "DEBUG";
     public static final String NONE = "NONE";
     public static final String START = "START"; // marks a beginning of a section
     public static final String DEFAULT = NONE;

--- a/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
@@ -32,7 +32,7 @@ public class LogParserDisplayConsts {
         linkListDisplayPlural.put(LogParserConsts.ERROR, "Errors");
         linkListDisplayPlural.put(LogParserConsts.WARNING, "Warnings");
         linkListDisplayPlural.put(LogParserConsts.INFO, "Infos");
-        linkListDisplayPlural.put(LogParserConsts.DEBUG, "DebugS");
+        linkListDisplayPlural.put(LogParserConsts.DEBUG, "Debugs");
     }
 
     public HashMap<String, String> getColorTable() {

--- a/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
@@ -15,20 +15,24 @@ public class LogParserDisplayConsts {
         colorTable.put(LogParserConsts.WARNING, "orange");
         colorTable.put(LogParserConsts.INFO, "blue");
         colorTable.put(LogParserConsts.START, "blue");
+        colorTable.put(LogParserConsts.DEBUG, "blue");
 
         // Icon for each status in the summary
         iconTable.put(LogParserConsts.ERROR, "red.gif");
         iconTable.put(LogParserConsts.WARNING, "yellow.gif");
         iconTable.put(LogParserConsts.INFO, "blue.gif");
+        iconTable.put(LogParserConsts.DEBUG, "blue.gif");
 
         // How to display in link summary html
         linkListDisplay.put(LogParserConsts.ERROR, "Error");
         linkListDisplay.put(LogParserConsts.WARNING, "Warning");
         linkListDisplay.put(LogParserConsts.INFO, "Info");
+        linkListDisplay.put(LogParserConsts.DEBUG, "Debug");
 
         linkListDisplayPlural.put(LogParserConsts.ERROR, "Errors");
         linkListDisplayPlural.put(LogParserConsts.WARNING, "Warnings");
         linkListDisplayPlural.put(LogParserConsts.INFO, "Infos");
+        linkListDisplayPlural.put(LogParserConsts.DEBUG, "DebugS");
     }
 
     public HashMap<String, String> getColorTable() {

--- a/src/main/java/hudson/plugins/logparser/LogParserParser.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserParser.java
@@ -50,6 +50,7 @@ public class LogParserParser {
         statusCount.put(LogParserConsts.ERROR, 0);
         statusCount.put(LogParserConsts.WARNING, 0);
         statusCount.put(LogParserConsts.INFO, 0);
+        statusCount.put(LogParserConsts.DEBUG, 0);
 
         this.parsingRulesArray = LogParserUtils
                 .readParsingRules(parsingRulesFile);
@@ -89,16 +90,17 @@ public class LogParserParser {
         // Determine parsed log files
         final String parsedFilePath = logDirectory + "/log_content.html";
         final String errorLinksFilePath = logDirectory + "/logerrorLinks.html";
-        final String warningLinksFilePath = logDirectory
-                + "/logwarningLinks.html";
+        final String warningLinksFilePath = logDirectory + "/logwarningLinks.html";
         final String infoLinksFilePath = logDirectory + "/loginfoLinks.html";
+        final String debugLinksFilePath = logDirectory + "/logdebugLinks.html";
         final String buildRefPath = logDirectory + "/log_ref.html";
         final String buildWrapperPath = logDirectory + "/log.html";
 
-        // Record file paths in hash
+        // Record file paths in HashMap
         linkFiles.put(LogParserConsts.ERROR, errorLinksFilePath);
         linkFiles.put(LogParserConsts.WARNING, warningLinksFilePath);
         linkFiles.put(LogParserConsts.INFO, infoLinksFilePath);
+        linkFiles.put(LogParserConsts.DEBUG, debugLinksFilePath);
 
         // Open console log for reading and all other files for writing
         final BufferedWriter writer = new BufferedWriter(new FileWriter(
@@ -111,18 +113,19 @@ public class LogParserParser {
                 warningLinksFilePath)));
         writers.put(LogParserConsts.INFO, new BufferedWriter(new FileWriter(
                 infoLinksFilePath)));
+        writers.put(LogParserConsts.DEBUG, new BufferedWriter(new FileWriter(
+                debugLinksFilePath)));
 
         // Loop on the console log as long as there are input lines and parse
         // line by line
         // At the end of this loop, we will have:
         // - a parsed log with colored lines
-        // - 3 links files which will be consolidated into one referencing html
+        // - 4 links files which will be consolidated into one referencing html
         // file.
 
         // Create dummy header and section for beginning of log
         final String shortLink = " <a target=\"content\" href=\"log_content.html\">Beginning of log</a>";
-        LogParserWriter.writeHeaderTemplateToAllLinkFiles(writers,
-                sectionCounter); // This enters a line which will later be
+        LogParserWriter.writeHeaderTemplateToAllLinkFiles(writers, sectionCounter); // This enters a line which will later be
                                  // replaced by the actual header and count for
                                  // this header
         headerForSection.add(shortLink);
@@ -146,6 +149,7 @@ public class LogParserParser {
         ((BufferedWriter) writers.get(LogParserConsts.ERROR)).close();
         ((BufferedWriter) writers.get(LogParserConsts.WARNING)).close();
         ((BufferedWriter) writers.get(LogParserConsts.INFO)).close();
+        ((BufferedWriter) writers.get(LogParserConsts.DEBUG)).close();
 
         // Build the reference html from the warnings/errors/info html files
         // created in the loop above
@@ -165,16 +169,16 @@ public class LogParserParser {
         final LogParserResult result = new LogParserResult();
         result.setHtmlLogFile(parsedFilePath);
         result.setTotalErrors((Integer) statusCount.get(LogParserConsts.ERROR));
-        result.setTotalWarnings((Integer) statusCount
-                .get(LogParserConsts.WARNING));
+        result.setTotalWarnings((Integer) statusCount.get(LogParserConsts.WARNING));
         result.setTotalInfos((Integer) statusCount.get(LogParserConsts.INFO));
+        result.setTotalDebugs((Integer) statusCount.get(LogParserConsts.DEBUG));
         result.setErrorLinksFile(errorLinksFilePath);
         result.setWarningLinksFile(warningLinksFilePath);
         result.setInfoLinksFile(infoLinksFilePath);
+        result.setDebugLinksFile(debugLinksFilePath);
         result.setParsedLogURL(parsedLogURL);
         result.setHtmlLogPath(logDirectory);
-        result.setBadParsingRulesError(this.compiledPatternsPlusError
-                .getError());
+        result.setBadParsingRulesError(this.compiledPatternsPlusError.getError());
 
         return result;
 

--- a/src/main/java/hudson/plugins/logparser/LogParserResult.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserResult.java
@@ -11,11 +11,13 @@ public class LogParserResult {
     private int totalErrors = 0;
     private int totalWarnings = 0;
     private int totalInfos = 0;
+    private int totalDebugs = 0;
 
     private String htmlLogFile;
     private String errorLinksFile;
     private String warningLinksFile;
     private String infoLinksFile;
+    private String debugLinksFile;
 
     private String parsedLogURL;
     private String htmlLogPath;
@@ -55,6 +57,10 @@ public class LogParserResult {
         return totalInfos;
     }
 
+    public int getTotalDebugs() {
+        return totalDebugs;
+    }
+
     public String getHtmlLogFile() {
         return htmlLogFile;
     }
@@ -73,6 +79,10 @@ public class LogParserResult {
 
     public String getInfoLinksFile() {
         return infoLinksFile;
+    }
+
+    public String getDebugLinksFile() {
+        return debugLinksFile;
     }
 
     public String getParsedLogURL() {
@@ -103,6 +113,10 @@ public class LogParserResult {
         return getReader(getInfoLinksFile());
     }
 
+    public Reader getDebugLinkedReader() throws IOException {
+        return getReader(getDebugLinksFile());
+    }
+
     public void setHtmlLogFile(final String file) {
         this.htmlLogFile = file;
     }
@@ -123,6 +137,10 @@ public class LogParserResult {
         this.infoLinksFile = file;
     }
 
+    public void setDebugLinksFile(final String file) {
+        this.debugLinksFile = file;
+    }
+
     public void setTotalErrors(final int totalErrors) {
         this.totalErrors = totalErrors;
     }
@@ -133,6 +151,10 @@ public class LogParserResult {
 
     public void setTotalInfos(final int totalInfos) {
         this.totalInfos = totalInfos;
+    }
+
+    public void setTotalDebugs(final int totalDebugs) {
+        this.totalDebugs = totalDebugs;
     }
 
     public void setParsedLogURL(final String parsedLogURL) {

--- a/src/main/java/hudson/plugins/logparser/LogParserWriter.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserWriter.java
@@ -75,8 +75,12 @@ public final class LogParserWriter {
         writeLinks(writer, LogParserConsts.WARNING, headerForSection,
                 statusCountPerSection, iconTable, linkListDisplay,
                 linkListDisplayPlural, statusCount, linkFiles);
-        // Write Info
+        // Write Infos
         writeLinks(writer, LogParserConsts.INFO, headerForSection,
+                statusCountPerSection, iconTable, linkListDisplay,
+                linkListDisplayPlural, statusCount, linkFiles);
+        // Write Debugs
+        writeLinks(writer, LogParserConsts.DEBUG, headerForSection,
                 statusCountPerSection, iconTable, linkListDisplay,
                 linkListDisplayPlural, statusCount, linkFiles);
         writer.write(LogParserConsts.getHtmlClosingTags());

--- a/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
@@ -22,40 +22,14 @@ public class LogParserWorkflowTest {
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
-    private static Maven.MavenInstallation mavenInstallation;
+    private static LogParserAction result;
 
     @BeforeClass
     public static void init() throws Exception {
-        mavenInstallation = jenkinsRule.configureMaven3();
-    }
-
-    /**
-     * Run a workflow job using {@link LogParserPublisher} and check for success.
-     */
-    @Test
-    public void logParserPublisherWorkflowStep() throws Exception {
+        Maven.MavenInstallation mavenInstallation = jenkinsRule.configureMaven3();
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "logParserPublisherWorkflowStep");
         FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
-        workspace.unzipFrom(getClass().getResourceAsStream("./maven-project1.zip"));
-        job.setDefinition(new CpsFlowDefinition(""
-                        + "node {\n"
-                        + "  def mvnHome = tool '" + mavenInstallation.getName() + "'\n"
-                        + "  sh \"${mvnHome}/bin/mvn clean install\"\n"
-                        + "  step([$class: 'LogParserPublisher', projectRulePath: 'logparser-rules.txt', useProjectRule: true])\n"
-                        + "}\n", true)
-        );
-        jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
-        LogParserAction result = job.getLastBuild().getAction(LogParserAction.class);
-        assertEquals(0, result.getResult().getTotalErrors());
-        assertEquals(2, result.getResult().getTotalWarnings());
-        assertEquals(0, result.getResult().getTotalInfos());
-    }
-
-    @Test
-    public void logParserPublisherWorkflowStepDebugTags() throws Exception {
-        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "logParserPublisherWorkflowStep");
-        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
-        workspace.unzipFrom(getClass().getResourceAsStream("./maven-project1.zip"));
+        workspace.unzipFrom(LogParserWorkflowTest.class.getResourceAsStream("./maven-project1.zip"));
         job.setDefinition(new CpsFlowDefinition(""
                 + "node {\n"
                 + "  def mvnHome = tool '" + mavenInstallation.getName() + "'\n"
@@ -64,8 +38,24 @@ public class LogParserWorkflowTest {
                 + "}\n", true)
         );
         jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
-        LogParserAction result = job.getLastBuild().getAction(LogParserAction.class);
-        assertEquals(0, result.getResult().getTotalDebugs());
+        result = job.getLastBuild().getAction(LogParserAction.class);
     }
 
+    /**
+     * Run a workflow job using {@link LogParserPublisher} and check for success.
+     */
+    @Test
+    public void logParserPublisherWorkflowStep() throws Exception {
+        assertEquals(0, result.getResult().getTotalErrors());
+        assertEquals(2, result.getResult().getTotalWarnings());
+        assertEquals(0, result.getResult().getTotalInfos());
+    }
+
+    /**
+     * Run a workflow job using {@link LogParserPublisher} and check for number of debug tags
+     */
+    @Test
+    public void logParserPublisherWorkflowStepDebugTags() throws Exception {
+        assertEquals(0, result.getResult().getTotalDebugs());
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
@@ -1,8 +1,10 @@
 package org.jenkinsci.plugins.logparser;
 
 import hudson.FilePath;
+import hudson.model.AbstractBuild;
 import hudson.plugins.logparser.LogParserAction;
 import hudson.plugins.logparser.LogParserPublisher;
+import hudson.plugins.logparser.LogParserResult;
 import hudson.tasks.Maven;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -10,6 +12,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 
@@ -52,5 +55,15 @@ public class LogParserWorkflowTest {
         assertEquals(0, result.getResult().getTotalDebugs());
     }
 
+    @Test
+    public void logParserTestDebugTag() throws Exception {
+        LogParserResult newResult = new LogParserResult();
+        newResult.setTotalDebugs(2);
+        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+        LogParserAction newAction = new LogParserAction(build, newResult);
+        Mockito.when(build.getAction(LogParserAction.class)).thenReturn(newAction);
+        LogParserAction result = build.getAction(LogParserAction.class);
+        assertEquals(2, result.getResult().getTotalDebugs());
+    }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
@@ -40,7 +40,7 @@ public class LogParserWorkflowTest {
         job.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  def mvnHome = tool '" + mavenInstallation.getName() + "'\n"
-                        + "  sh \"export M2_HOME=${mvnHome};${mvnHome}/bin/mvn clean install\"\n"
+                        + "  sh \"${mvnHome}/bin/mvn clean install\"\n"
                         + "  step([$class: 'LogParserPublisher', projectRulePath: 'logparser-rules.txt', useProjectRule: true])\n"
                         + "}\n", true)
         );

--- a/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
@@ -52,4 +52,5 @@ public class LogParserWorkflowTest {
         assertEquals(0, result.getResult().getTotalDebugs());
     }
 
+
 }

--- a/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
@@ -40,7 +40,7 @@ public class LogParserWorkflowTest {
         job.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  def mvnHome = tool '" + mavenInstallation.getName() + "'\n"
-                        + "  sh \"${mvnHome}/bin/mvn clean install\"\n"
+                        + "  sh \"export M2_HOME=${mvnHome};${mvnHome}/bin/mvn clean install\"\n"
                         + "  step([$class: 'LogParserPublisher', projectRulePath: 'logparser-rules.txt', useProjectRule: true])\n"
                         + "}\n", true)
         );
@@ -49,6 +49,7 @@ public class LogParserWorkflowTest {
         assertEquals(0, result.getResult().getTotalErrors());
         assertEquals(2, result.getResult().getTotalWarnings());
         assertEquals(0, result.getResult().getTotalInfos());
+        assertEquals(0, result.getResult().getTotalDebugs());
     }
 
 }


### PR DESCRIPTION
This pull request add support for parsing console output lines as "debug tags". An image preview is attached below.
![capture](https://cloud.githubusercontent.com/assets/3282172/11357495/626b2638-922d-11e5-9e1c-bed7e6440cfa.JPG)
Test has also been fixed as mentioned in PR #11 