### PR TITLE
Adding a parsing of basic info out of the log 

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserConsts.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserConsts.java
@@ -13,6 +13,7 @@ public class LogParserConsts {
     public static final String NONE = "NONE";
     public static final String START = "START"; // marks a beginning of a section
     public static final String DEFAULT = NONE;
+    public static final String BASIC = "BASIC";
 
     // Error messages
     public static final String CANNOT_PARSE = "log-parser plugin ERROR: Cannot parse log ";
@@ -21,7 +22,11 @@ public class LogParserConsts {
     public static final List<String> LEGAL_STATUS = Arrays.asList(ERROR, WARNING, INFO, NONE, START);
     public static final List<String> STATUSES_WITH_LINK_FILES = Arrays.asList(ERROR, WARNING, INFO);
     public static final List<String> STATUSES_WITH_SECTIONS_IN_LINK_FILES = Arrays.asList(ERROR, WARNING);
-
+    
+    public static final String[] BASIC_INFO_LINES={"Maven Version:","JDK Version:",
+		"OS Info:","Total time:",
+		"Finished at:","Final Memory:"};
+    
     public static String getHtmlOpeningTags() {
         final String hudsonRoot = Jenkins.getActiveInstance().getRootUrl();
         return "<!DOCTYPE html>\n" + "<html>\n" + "\t<head>\n"

--- a/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
@@ -15,20 +15,22 @@ public class LogParserDisplayConsts {
         colorTable.put(LogParserConsts.WARNING, "orange");
         colorTable.put(LogParserConsts.INFO, "blue");
         colorTable.put(LogParserConsts.START, "blue");
-
+        colorTable.put(LogParserConsts.BASIC, "blue");
         // Icon for each status in the summary
         iconTable.put(LogParserConsts.ERROR, "red.gif");
         iconTable.put(LogParserConsts.WARNING, "yellow.gif");
         iconTable.put(LogParserConsts.INFO, "blue.gif");
-
+        iconTable.put(LogParserConsts.BASIC, "blue.gif");
         // How to display in link summary html
         linkListDisplay.put(LogParserConsts.ERROR, "Error");
         linkListDisplay.put(LogParserConsts.WARNING, "Warning");
         linkListDisplay.put(LogParserConsts.INFO, "Info");
-
+        linkListDisplay.put(LogParserConsts.BASIC, "Basic");
+        
         linkListDisplayPlural.put(LogParserConsts.ERROR, "Errors");
         linkListDisplayPlural.put(LogParserConsts.WARNING, "Warnings");
         linkListDisplayPlural.put(LogParserConsts.INFO, "Infos");
+        linkListDisplayPlural.put(LogParserConsts.BASIC, "Basic");
     }
 
     public HashMap<String, String> getColorTable() {

--- a/src/main/java/hudson/plugins/logparser/LogParserParser.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserParser.java
@@ -19,6 +19,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringUtils;
+
 public class LogParserParser {
 
     final private HashMap<String, Integer> statusCount = new HashMap<String, Integer>();
@@ -50,7 +52,7 @@ public class LogParserParser {
         statusCount.put(LogParserConsts.ERROR, 0);
         statusCount.put(LogParserConsts.WARNING, 0);
         statusCount.put(LogParserConsts.INFO, 0);
-
+        statusCount.put(LogParserConsts.BASIC, 0);
         this.parsingRulesArray = LogParserUtils
                 .readParsingRules(parsingRulesFile);
 
@@ -92,6 +94,7 @@ public class LogParserParser {
         final String warningLinksFilePath = logDirectory
                 + "/logwarningLinks.html";
         final String infoLinksFilePath = logDirectory + "/loginfoLinks.html";
+        final String basicLinksFilePath = logDirectory +"/logbasicLinks.html";
         final String buildRefPath = logDirectory + "/log_ref.html";
         final String buildWrapperPath = logDirectory + "/log.html";
 
@@ -99,7 +102,7 @@ public class LogParserParser {
         linkFiles.put(LogParserConsts.ERROR, errorLinksFilePath);
         linkFiles.put(LogParserConsts.WARNING, warningLinksFilePath);
         linkFiles.put(LogParserConsts.INFO, infoLinksFilePath);
-
+        linkFiles.put(LogParserConsts.BASIC, basicLinksFilePath);
         // Open console log for reading and all other files for writing
         final BufferedWriter writer = new BufferedWriter(new FileWriter(
                 parsedFilePath));
@@ -111,7 +114,8 @@ public class LogParserParser {
                 warningLinksFilePath)));
         writers.put(LogParserConsts.INFO, new BufferedWriter(new FileWriter(
                 infoLinksFilePath)));
-
+        writers.put(LogParserConsts.BASIC, new BufferedWriter(new FileWriter(
+        		basicLinksFilePath)));
         // Loop on the console log as long as there are input lines and parse
         // line by line
         // At the end of this loop, we will have:
@@ -146,7 +150,7 @@ public class LogParserParser {
         ((BufferedWriter) writers.get(LogParserConsts.ERROR)).close();
         ((BufferedWriter) writers.get(LogParserConsts.WARNING)).close();
         ((BufferedWriter) writers.get(LogParserConsts.INFO)).close();
-
+        ((BufferedWriter) writers.get(LogParserConsts.BASIC)).close();
         // Build the reference html from the warnings/errors/info html files
         // created in the loop above
         LogParserWriter.writeReferenceHtml(buildRefPath, headerForSection,
@@ -168,9 +172,11 @@ public class LogParserParser {
         result.setTotalWarnings((Integer) statusCount
                 .get(LogParserConsts.WARNING));
         result.setTotalInfos((Integer) statusCount.get(LogParserConsts.INFO));
+        result.setBasicInfos((Integer) statusCount.get(LogParserConsts.BASIC));
         result.setErrorLinksFile(errorLinksFilePath);
         result.setWarningLinksFile(warningLinksFilePath);
         result.setInfoLinksFile(infoLinksFilePath);
+        result.setBasicLinksFile(basicLinksFilePath);
         result.setParsedLogURL(parsedLogURL);
         result.setHtmlLogPath(logDirectory);
         result.setBadParsingRulesError(this.compiledPatternsPlusError
@@ -188,6 +194,9 @@ public class LogParserParser {
             throws IOException {
         String parsedLine = line;
         String effectiveStatus = status;
+        if (checkBasicInfoLine(line)){
+        	effectiveStatus = LogParserConsts.BASIC;
+        }
         if (status == null) {
             effectiveStatus = LogParserConsts.NONE;
         } else if (status.equals(LogParserConsts.START)) {
@@ -338,5 +347,13 @@ public class LogParserParser {
                 + " minutes (" + diffSeconds + ") seconds.");
 
     }
+    /**
+     * A function that checks whether or not the line is basic or not.
+     * @param line
+     * @return boolean whether or not the line fits any of the strings that identify it as a basic line
+    */
+    private boolean checkBasicInfoLine(String line){
+		return (StringUtils.indexOfAny(line, LogParserConsts.BASIC_INFO_LINES)!=-1);
+	}
 
 }

--- a/src/main/java/hudson/plugins/logparser/LogParserResult.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserResult.java
@@ -11,12 +11,14 @@ public class LogParserResult {
     private int totalErrors = 0;
     private int totalWarnings = 0;
     private int totalInfos = 0;
+    private int basicInfos = 0;
 
     private String htmlLogFile;
     private String errorLinksFile;
     private String warningLinksFile;
     private String infoLinksFile;
-
+    private String basicLinksFile;
+    
     private String parsedLogURL;
     private String htmlLogPath;
 
@@ -54,7 +56,11 @@ public class LogParserResult {
     public int getTotalInfos() {
         return totalInfos;
     }
-
+    
+    public int getBasicInfos(){
+    	return basicInfos;
+    }
+    
     public String getHtmlLogFile() {
         return htmlLogFile;
     }
@@ -74,7 +80,11 @@ public class LogParserResult {
     public String getInfoLinksFile() {
         return infoLinksFile;
     }
-
+    
+    public String getBasicLinksFile(){
+    	return basicLinksFile;
+    }
+    
     public String getParsedLogURL() {
         return parsedLogURL;
     }
@@ -122,6 +132,10 @@ public class LogParserResult {
     public void setInfoLinksFile(final String file) {
         this.infoLinksFile = file;
     }
+    
+    public void setBasicLinksFile(final String file){
+    	this.basicLinksFile = file;
+    }
 
     public void setTotalErrors(final int totalErrors) {
         this.totalErrors = totalErrors;
@@ -133,6 +147,10 @@ public class LogParserResult {
 
     public void setTotalInfos(final int totalInfos) {
         this.totalInfos = totalInfos;
+    }
+
+    public void setBasicInfos(final int basicInfos){
+    	this.basicInfos = basicInfos;
     }
 
     public void setParsedLogURL(final String parsedLogURL) {

--- a/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
@@ -49,6 +49,7 @@ public class LogParserWorkflowTest {
         assertEquals(0, result.getResult().getTotalErrors());
         assertEquals(2, result.getResult().getTotalWarnings());
         assertEquals(0, result.getResult().getTotalInfos());
+        assertEquals(0, result.getResult().getBasicInfos());
     }
 
 }


### PR DESCRIPTION
Added a feature to allow the log parser to pull out basic info out of the log. Basic info includes: jdk version, maven version, build finished time, build completion time, and total memory usage.

The jira page for this page can be found at. https://issues.jenkins-ci.org/browse/JENKINS-31927
