### PR TITLE
UX improvements: "show only this" link, more compact/usable list of results

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserParser.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserParser.java
@@ -127,6 +127,15 @@ public class LogParserParser {
                                  // this header
         headerForSection.add(shortLink);
         writer.write(LogParserConsts.getHtmlOpeningTags());
+		
+		// write styles for log body
+        final String styles = "<style>\n"
+			+ "  body {margin-left:.5em; }\n"
+			+ "  pre {font-family: Consolas, \"Courier New\"; word-wrap: break-word; }\n"
+			+ "  pre span {word-wrap: break-word; } \n"
+			+ "</style>\n";
+        writer.write(styles);
+
         if (this.preformattedHtml)
             writer.write("<pre>");
         // Read bulks of lines, parse
@@ -240,9 +249,10 @@ public class LogParserParser {
     }
 
     private String colorLine(final String line, final String status) {
-        final String color = (String) displayConstants.getColorTable().get(
-                status);
-        final StringBuffer result = new StringBuffer("<span style=\"color:");
+        final String color = (String) displayConstants.getColorTable().get(status);
+        final StringBuffer result = new StringBuffer("<span class=\"");
+        result.append(status.toLowerCase());
+        result.append("\" style=\"color:");
         result.append(color);
         result.append("\">");
         result.append(line);
@@ -269,7 +279,7 @@ public class LogParserParser {
         final StringBuffer link = new StringBuffer("<li>");
         link.append(statusCountStr);
         link.append(shortLink);
-        link.append("</li><br/>");
+        link.append("</li>");
 
         final BufferedWriter linkWriter = (BufferedWriter) writers
                 .get(effectiveStatus);

--- a/src/main/java/hudson/plugins/logparser/LogParserWriter.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserWriter.java
@@ -100,14 +100,24 @@ public final class LogParserWriter {
                 .toString();
 
         final String hudsonRoot = Hudson.getInstance().getRootUrl();
-        final String iconLocation = String.format("%s/images/16x16/",
-                Functions.getResourcePath());
+        final String iconLocation = String.format("%s/images/16x16/", Functions.getResourcePath());
+		
+        final String styles = 
+            "<style>\n" 
+            + "    ul {margin-left: 0; padding-left: 1em;}\n"
+            + "    ul li {font-size: small; white-space: nowrap; text-overflow: ellipsis; overflow: hidden; margin-top: .5em; }\n"
+            + "    ul li:hover {white-space: normal;}\n"
+            + "    ul li a:link {text-decoration: none;}\n"
+            + "    ul li:hover a:link {text-decoration: underline;}\n"
+            + "</style>\n";
+        writer.write(styles);
+		
         final String linksStart = "<img src=\"" + hudsonRoot + "/" + iconLocation + statusIcon
                 + "\" style=\"margin: 2px;\" width=\"24\" alt=\"" + linkListDisplayStr + " Icon\" height=\"24\" />\n"
                 + "<a href=\"javascript:toggleList('" + linkListDisplayStr + "')\" target=\"_self\"><STRONG>"
-                + linkListDisplayStr + " (" + linkListCount + ")</STRONG></a><br />\n" + "<ul id=\""
-                + linkListDisplayStr + "\" style=\"display:none; margin-left:0; padding-left:3em\">\n";
-
+                + linkListDisplayStr + " (" + linkListCount + ")</STRONG></a><br />\n"
+                + "<ul style=\"display: none;\" id=\""
+                + linkListDisplayStr + "\" >\n";
         writer.write(linksStart);
 
         // Read the links file and insert here

--- a/src/main/resources/hudson/plugins/logparser/LogParserAction/index.jelly
+++ b/src/main/resources/hudson/plugins/logparser/LogParserAction/index.jelly
@@ -11,6 +11,7 @@
           <tr>
             <td width="100%">
               <h2>Parsed Console Output</h2>
+              <a href="${it.result.parsedLogURL}">Show only this</a>
               <iframe src="${it.result.parsedLogURL}" width="100%" height="600" scrolling="auto" frameborder="0"/>
             </td>
           </tr>


### PR DESCRIPTION
Two UX improvements:
- "Show only this" link to same results frameset
- More compact list of errors/warnings/infos with ellipses, which expand when hovered.

These are the first enhancements we at General Mills are making so that our developers can have a better time with parsed logs.
