### PR TITLE
Add logparser step that returns a LogParserResult for use in pipeline scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.596.1</version>
+    <version>2.13</version>
+    <relativePath/>
   </parent>
 
   <artifactId>log-parser</artifactId>
@@ -19,6 +20,7 @@
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <workflow-jenkins-plugin.version>1.7</workflow-jenkins-plugin.version>
+    <jenkins.version>1.596.1</jenkins.version>
   </properties>
 
   <licenses>
@@ -68,6 +70,13 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-aggregator</artifactId>
       <version>${workflow-jenkins-plugin.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness-tools</artifactId>
+      <version>2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,18 @@
     </developer>
   </developers>
 
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -97,15 +109,10 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.2</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.10.3</version>
         <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <additionalparam>${javadoc.opts}</additionalparam>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/hudson/plugins/logparser/LogParserPipelineStep.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserPipelineStep.java
@@ -1,0 +1,102 @@
+package hudson.plugins.logparser;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Created by acearl on 12/15/2016.
+ */
+public class LogParserPipelineStep extends AbstractStepImpl {
+
+    private final boolean useProjectRule;
+    private final String projectRulePath;
+    private final String parsingRulesPath;
+    private boolean unstableOnWarning;
+    private boolean failBuildOnError;
+    private boolean showGraphs;
+
+    @DataBoundConstructor
+    public LogParserPipelineStep(boolean useProjectRule, String projectRulePath, String parsingRulesPath) {
+        this.useProjectRule = useProjectRule;
+        this.projectRulePath = projectRulePath;
+        this.parsingRulesPath = parsingRulesPath;
+    }
+
+    @DataBoundSetter
+    public void setUnstableOnWarning(boolean unstableOnWarning) {
+        this.unstableOnWarning = unstableOnWarning;
+    }
+
+    @DataBoundSetter
+    public void setFailBuildOnError(boolean failBuildOnError) {
+        this.failBuildOnError = failBuildOnError;
+    }
+
+    @DataBoundSetter
+    public void setShowGraphs(boolean showGraphs) {
+        this.showGraphs = showGraphs;
+    }
+
+    public static class LogParserStepExecution extends AbstractSynchronousStepExecution<LogParserResult> {
+        private static final long serialVersionUID = 1L;
+
+        @Inject
+        private transient LogParserPipelineStep step;
+
+        @StepContextParameter
+        private transient Run<?,?> run;
+
+        @StepContextParameter
+        private transient FilePath workspace;
+
+        @StepContextParameter
+        private transient TaskListener listener;
+
+        @StepContextParameter
+        private transient Launcher launcher;
+
+        @Override
+        protected LogParserResult run() throws Exception {
+            LogParserPublisher publisher = new LogParserPublisher(step.useProjectRule, step.projectRulePath, step.parsingRulesPath);
+            publisher.setFailBuildOnError(step.failBuildOnError);
+            publisher.setUnstableOnWarning(step.unstableOnWarning);
+            publisher.setShowGraphs(step.showGraphs);
+
+            publisher.perform(run, workspace, launcher, listener);
+            LogParserAction action = run.getAction(LogParserAction.class);
+            if(action != null) {
+                return action.getResult();
+            }
+            return null;
+        }
+    }
+
+    @Extension(optional=true)
+    public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(LogParserStepExecution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "logparser";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Log Parser";
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/logparser/LogParserResult.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserResult.java
@@ -1,5 +1,7 @@
 package hudson.plugins.logparser;
 
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -35,6 +37,7 @@ public class LogParserResult {
         this.badParsingRulesError = badParsingRulesError;
     }
 
+    @Whitelisted
     public String getFailedToParseError() {
         return failedToParseError;
     }
@@ -43,38 +46,47 @@ public class LogParserResult {
         this.failedToParseError = failedToParseError;
     }
 
+    @Whitelisted
     public int getTotalErrors() {
         return totalErrors;
     }
 
+    @Whitelisted
     public int getTotalWarnings() {
         return totalWarnings;
     }
 
+    @Whitelisted
     public int getTotalInfos() {
         return totalInfos;
     }
 
+    @Whitelisted
     public String getHtmlLogFile() {
         return htmlLogFile;
     }
 
+    @Whitelisted
     public String getHtmlLogPath() {
         return htmlLogPath;
     }
 
+    @Whitelisted
     public String getErrorLinksFile() {
         return errorLinksFile;
     }
 
+    @Whitelisted
     public String getWarningLinksFile() {
         return warningLinksFile;
     }
 
+    @Whitelisted
     public String getInfoLinksFile() {
         return infoLinksFile;
     }
 
+    @Whitelisted
     public String getParsedLogURL() {
         return parsedLogURL;
     }
@@ -143,6 +155,7 @@ public class LogParserResult {
         return new File(this.htmlLogFile);
     }
 
+    @Whitelisted
     public String getHtmlContent() {
         final StringBuffer result = new StringBuffer("");
         String line = "";

--- a/src/main/resources/hudson/plugins/logparser/LogParserAction/index.jelly
+++ b/src/main/resources/hudson/plugins/logparser/LogParserAction/index.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="parseSucceeded" value="${it.result.failedToParseError == null}"/>
   <j:set var="parseFailed" value="${it.result.failedToParseError != null}"/>

--- a/src/main/resources/hudson/plugins/logparser/LogParserAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/logparser/LogParserAction/summary.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:set var="parseSucceeded" value="${it.result.failedToParseError == null}"/>
   <j:set var="parseFailed" value="${it.result.failedToParseError != null}"/>

--- a/src/main/resources/hudson/plugins/logparser/LogParserPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/logparser/LogParserPublisher/config.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Mark build Unstable on Warning" help="/plugin/log-parser/unstable_on_warning.html">
     <f:checkbox name="log-parser.unstableOnWarning" checked="${instance.unstableOnWarning}"/>

--- a/src/main/resources/hudson/plugins/logparser/LogParserPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/logparser/LogParserPublisher/global.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Console Output Parsing" name="log-parser">
     <f:entry title="Parsing Rules" help="/plugin/log-parser/global_config_help.html">

--- a/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/LogParserWorkflowTest.java
@@ -1,17 +1,24 @@
 package org.jenkinsci.plugins.logparser;
 
 import hudson.FilePath;
+import hudson.Functions;
+import hudson.model.Run;
 import hudson.plugins.logparser.LogParserAction;
 import hudson.plugins.logparser.LogParserPublisher;
 import hudson.tasks.Maven;
+import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.ToolInstallations;
+
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * In this test suite we initialize the Job workspaces with a resource (maven-project1.zip) that contains a Maven
@@ -26,7 +33,7 @@ public class LogParserWorkflowTest {
 
     @BeforeClass
     public static void init() throws Exception {
-        mavenInstallation = jenkinsRule.configureMaven3();
+        mavenInstallation = ToolInstallations.configureMaven3();
     }
 
     /**
@@ -40,7 +47,7 @@ public class LogParserWorkflowTest {
         job.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  def mvnHome = tool '" + mavenInstallation.getName() + "'\n"
-                        + "  sh \"${mvnHome}/bin/mvn clean install\"\n"
+                        + "  " + (Functions.isWindows() ? "bat" : "sh") +  "\"${mvnHome}/bin/mvn clean install\"\n"
                         + "  step([$class: 'LogParserPublisher', projectRulePath: 'logparser-rules.txt', useProjectRule: true])\n"
                         + "}\n", true)
         );
@@ -51,4 +58,30 @@ public class LogParserWorkflowTest {
         assertEquals(0, result.getResult().getTotalInfos());
     }
 
+    @Test
+    public void logParserPublisherPipelineStep() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "logParserPublisherWorkflowStep");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        workspace.unzipFrom(getClass().getResourceAsStream("./maven-project1.zip"));
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node {\n"
+                + "  def mvnHome = tool '" + mavenInstallation.getName() + "'\n"
+                + "  " + (Functions.isWindows() ? "bat" : "sh") + " \"${mvnHome}/bin/mvn clean install\"\n"
+                + "  def res = logparser(projectRulePath: 'logparser-rules.txt', useProjectRule: true)\n"
+                + "  echo \"Total Errors: ${res.totalErrors}\"\n"
+                + "  echo \"Total Warnings: ${res.totalWarnings}\"\n"
+                + "  echo \"Total Infos: ${res.totalInfos}\"\n"
+                + "}\n", true)
+        );
+        Run<?,?> build = job.scheduleBuild2(0).get();
+        jenkinsRule.assertBuildStatusSuccess(build);
+        LogParserAction result = build.getAction(LogParserAction.class);
+        assertEquals(0, result.getResult().getTotalErrors());
+        assertEquals(2, result.getResult().getTotalWarnings());
+        assertEquals(0, result.getResult().getTotalInfos());
+        String log = FileUtils.readFileToString(build.getLogFile());
+        assertTrue(log.contains("Total Errors: 0"));
+        assertTrue(log.contains("Total Warnings: 2"));
+        assertTrue(log.contains("Total Infos: 0"));
+    }
 }


### PR DESCRIPTION
This adds an explicit logparser step for pipeline that returns a LogParserResult for use in pipeline scripts. Pipelines could then check some of the values of the LogParserResult for decision making.