### PR TITLE
Plugin uses Hudson resources; lack of gray causes broken links

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
@@ -27,13 +27,13 @@ public class LogParserDisplayConsts {
         colorTable.put(LogParserConsts.WARNING, "orange");
         colorTable.put(LogParserConsts.INFO, "blue");
         colorTable.put(LogParserConsts.START, "blue");
-        colorTable.put(LogParserConsts.DEBUG, "gray");
+        colorTable.put(LogParserConsts.DEBUG, "grey");
 
         // Icon for each status in the summary
         iconTable.put(LogParserConsts.ERROR, "red.gif");
         iconTable.put(LogParserConsts.WARNING, "yellow.gif");
         iconTable.put(LogParserConsts.INFO, "blue.gif");
-        iconTable.put(LogParserConsts.DEBUG, "gray.gif");
+        iconTable.put(LogParserConsts.DEBUG, "grey.gif");
 
         // How to display in link summary html
         linkListDisplay.put(LogParserConsts.ERROR, "Error");


### PR DESCRIPTION
## :memo: Description

The plugin uses icon resources from Jenkins. Recent colour refactoring uses icon names not available in Jenkins. Perhaps the intention was to provide own icons, but it seems an unnecessary duplication.

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I verified that the modified plugin correctly uses the icon available in Jenkins

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
