### PR TITLE
JENKINS-59218: avoid NPE after deserializing old LogParserResult inst…

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserResult.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserResult.java
@@ -33,6 +33,13 @@ public class LogParserResult {
     private String failedToParseError;
     private String badParsingRulesError;
 
+    protected Object readResolve() {
+        if (extraTags == null) { // avoid NPE when deserializing old results
+        	extraTags = new HashSet<>();
+        }
+        return this;
+    }
+
     public String getBadParsingRulesError() {
         return badParsingRulesError;
     }


### PR DESCRIPTION
Fixes the NPE from JENKINS-59218. It occurs when an instance of LogParserResult is deserialized that was persisted before commit 95bd18013b96412d404100c80ce4c7e2b57f5536.

### :dart: Relevant issues
JENKINS-59218

### :gem: Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

We experienced the NPE ourselves, with the NPE in the log and the broken Log Parser Trend.  After installing the fixed version, no new NPEs occurred and the Log Parser Trend was correct again.

## :checkered_flag: Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [x ] I have commented my code, particularly in hard-to-understand areas

org.jenkinsci.plugins.logparser.LogParserWorkflowTest does not run successfully here (even without my change).