### PR TITLE
Replace a deprecated API

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserConsts.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserConsts.java
@@ -24,7 +24,7 @@ public class LogParserConsts {
     public static final List<String> STATUSES_WITH_SECTIONS_IN_LINK_FILES = Arrays.asList(ERROR, WARNING, DEBUG);
 
     public static String getHtmlOpeningTags() {
-        final String hudsonRoot = Jenkins.getActiveInstance().getRootUrl();
+        final String hudsonRoot = Jenkins.get().getRootUrl();
         return "<!DOCTYPE html>\n" + "<html>\n" + "\t<head>\n"
                 + "\t\t<title>log-parser plugin page</title>\n"
                 + "\t\t<link type=\"text/css\" rel=\"stylesheet\" href=\""

--- a/src/main/java/hudson/plugins/logparser/LogParserPublisher.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserPublisher.java
@@ -147,7 +147,7 @@ public class LogParserPublisher extends Recorder implements SimpleBuildStep, Ser
 
     @Override
     public BuildStepDescriptor<Publisher> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(LogParserPublisher.DescriptorImpl.class);
+        return Jenkins.get().getDescriptorByType(LogParserPublisher.DescriptorImpl.class);
     }
 
     @Extension @Symbol("logParser")

--- a/src/main/java/hudson/plugins/logparser/LogParserWriter.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserWriter.java
@@ -1,7 +1,7 @@
 package hudson.plugins.logparser;
 
 import hudson.Functions;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -117,7 +117,7 @@ public final class LogParserWriter {
         }
         final String linkListCount = statusCount.get(status).toString();
 
-        final String hudsonRoot = Hudson.getInstance().getRootUrl();
+        final String hudsonRoot = Jenkins.get().getRootUrl();
         final String iconLocation = String.format("%s/images/16x16/", Functions.getResourcePath());
 		
         final String styles = 

--- a/src/test/java/org/jenkinsci/plugins/logparser/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/logparser/ConfigurationAsCodeTest.java
@@ -22,17 +22,14 @@ public class ConfigurationAsCodeTest {
 
     @Test
     public void LegacyFormattingTest() throws Exception {
-        final Jenkins jenkins = Jenkins.getInstance();
-        final LogParserPublisher.DescriptorImpl descriptor = (LogParserPublisher.DescriptorImpl) jenkins.getDescriptor(LogParserPublisher.class);
+        final LogParserPublisher.DescriptorImpl descriptor = (LogParserPublisher.DescriptorImpl) Jenkins.get().getDescriptor(LogParserPublisher.class);
         ConfigurationAsCode.get().configure(ConfigurationAsCodeTest.class.getResource("configuration-as-code-legacy-formatting.yaml").toString());
         assertEquals(true, descriptor.getLegacyFormatting());
     }
 
     @Test
     public void ParsingRulesTest() throws Exception {
-        final Jenkins jenkins = Jenkins.getInstance();
-        final LogParserPublisher.DescriptorImpl descriptor = (LogParserPublisher.DescriptorImpl) jenkins.getDescriptor(LogParserPublisher.class);
-
+        final LogParserPublisher.DescriptorImpl descriptor = (LogParserPublisher.DescriptorImpl) Jenkins.get().getDescriptor(LogParserPublisher.class);
         ConfigurationAsCode.get().configure(ConfigurationAsCodeTest.class.getResource("configuration-as-code-parsing-rules.yaml").toString());
         List<ParserRuleFile> parseRuleFiles = descriptor.getParsingRulesGlobal();
 


### PR DESCRIPTION
## :memo: Description

This change gets rid of compiler warnings about a deprecated API.

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Fix compilation warnings

## :vertical_traffic_light: How Has This Been Tested?

I ran the unit tests and installed the modified plugin in a private instance of Jenkins.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
