### PR TITLE
JENKINS-67690: Jenkins Log Parser Debug Icon not shown

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserDisplayConsts.java
@@ -33,7 +33,7 @@ public class LogParserDisplayConsts {
         iconTable.put(LogParserConsts.ERROR, "red.gif");
         iconTable.put(LogParserConsts.WARNING, "yellow.gif");
         iconTable.put(LogParserConsts.INFO, "blue.gif");
-        iconTable.put(LogParserConsts.DEBUG, "grey.gif");
+        iconTable.put(LogParserConsts.DEBUG, "gray.gif");
 
         // How to display in link summary html
         linkListDisplay.put(LogParserConsts.ERROR, "Error");

--- a/src/main/java/hudson/plugins/logparser/LogParserWriter.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserWriter.java
@@ -118,7 +118,7 @@ public final class LogParserWriter {
         final String linkListCount = statusCount.get(status).toString();
 
         final String hudsonRoot = Jenkins.get().getRootUrl();
-        final String iconLocation = String.format("%s/images/16x16/", Functions.getResourcePath());
+        final String iconLocation = String.format("%s/plugin/log-parser/images/", jenkins.model.Jenkins.RESOURCE_PATH).substring(1);
 		
         final String styles = 
             "<style>\n" 
@@ -130,7 +130,7 @@ public final class LogParserWriter {
             + "</style>\n";
         writer.write(styles);
 		
-        final String linksStart = "<img src=\"" + hudsonRoot + "/" + iconLocation + statusIcon
+        final String linksStart = "<img src=\"" + hudsonRoot + iconLocation + statusIcon
                 + "\" style=\"margin: 2px;\" width=\"24\" alt=\"" + linkListDisplayStr + " Icon\" height=\"24\" />\n"
                 + "<a href=\"javascript:toggleList('" + linkListDisplayStr + "')\" target=\"_self\"><STRONG>"
                 + linkListDisplayStr + " (" + linkListCount + ")</STRONG></a><br />\n"


### PR DESCRIPTION
see [JENKINS-67690](https://issues.jenkins.io/browse/JENKINS-67690)

## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
