### PR TITLE
Fix potential OOM when parsing logs in workflows

### DIFF
--- a/src/main/java/hudson/plugins/logparser/LogParserParser.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserParser.java
@@ -353,10 +353,7 @@ public class LogParserParser {
 
         // Read log file from start - line by line and apply the statuses as
         // found by the threads.
-        final InputStreamReader streamReader = new InputStreamReader(
-                build.getLogInputStream(),
-                build.getCharset() );
-        final BufferedReader reader = new BufferedReader( streamReader );
+        final BufferedReader reader = new BufferedReader( build.getLogReader() );
         String line;
         String status;
         int line_num = 0;


### PR DESCRIPTION
## :memo: Description

`WorkflowRun.getLogInputStream` will read the entire log output into a `ByteArrayOutputStream`, then construct a `ByteArrayInputStream` from that buffer, which we then construct a `InputStreamReader` from. (https://github.com/jenkinsci/workflow-job-plugin/blob/1551f82/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L1105)

If the log is large, this will potentially cause a `java.lang.OutOfMemoryError`. Instead, use `build.getLogReader()`, which simply constructs an `InputStreamReader` that wraps the underlying source log session.

For `hudson.model.Run` this should have no impact, as its `getLogReader()` just constructs an `InputStreamReader` the same way we used to.



### :gem: Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Deployed to our Jenkins that (due to some overactive logging facilities) spewed ~130MB of logs, causing an OOM in the log parser.

Here's the exception we'd hit before this change had been deployed:
```
  java.lang.OutOfMemoryError: Java heap space
  	at java.base/java.util.Arrays.copyOf(Arrays.java:3745)
  	at java.base/java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:120)
  	at java.base/java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:95)
  	at java.base/java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:156)
  	at org.apache.commons.io.output.ProxyOutputStream.write(ProxyOutputStream.java:92)
  	at org.kohsuke.stapler.framework.io.LargeText$HeadMark.moveTo(LargeText.java:329)
  	at org.kohsuke.stapler.framework.io.LargeText.writeLogTo(LargeText.java:244)
  	at hudson.console.AnnotatedLargeText.writeRawLogTo(AnnotatedLargeText.java:173)
  	at org.jenkinsci.plugins.workflow.job.WorkflowRun$$Lambda$842/0x00000008414b1840.writeLogTo(Unknown Source)
  	at org.jenkinsci.plugins.workflow.job.WorkflowRun.writeLogTo(WorkflowRun.java:1140)
  	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getLogInputStream(WorkflowRun.java:1108)
  	at hudson.plugins.logparser.LogParserParser.parseLogBody(LogParserParser.java:357)
  	at hudson.plugins.logparser.LogParserParser.parseLog(LogParserParser.java:161)
  	at hudson.plugins.logparser.LogParserPublisher.perform(LogParserPublisher.java:117)
  	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
  	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:101)
  	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:71)
  	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
  	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$$Lambda$719/0x00000008410b6040.run(Unknown Source)
  	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  	at java.base/java.lang.Thread.run(Thread.java:829)
```

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works** -- I don't see any unit tests that cover this functionality, and I'm not sure how to construct a test that generates an OOM.
- [X] **New and existing unit tests pass locally with my changes**
