### PR TITLE
Introduce `StreamParsingStrategy` to support builds with large logs

### DIFF
--- a/src/main/java/hudson/plugins/logparser/ClassicParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/ClassicParsingStrategy.java
@@ -1,0 +1,89 @@
+package hudson.plugins.logparser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+class ClassicParsingStrategy implements ParsingStrategy {
+    @Override
+    public HashMap<String, String> parse(ParsingInput input) {
+        BufferedReader reader = input.getReader();
+        String tempFileLocation = input.getLogPath();
+        String[] parsingRulesArray = input.getParsingRulesArray();
+        Pattern[] compiledPatterns = input.getCompiledPatterns();
+        int threadCounter = 0;
+
+        final ArrayList<LogParserThread> runners = new ArrayList<>();
+        final LogParserReader logParserReader = new LogParserReader(reader);
+
+        try {
+            final ExecutorService execSvc = Executors.newCachedThreadPool();
+            int linesInLog = LogParserUtils.countLines(tempFileLocation);
+            final int threadsNeeded = linesInLog
+                    / LogParserUtils.getLinesPerThread() + 1;
+
+            // Read and parse the log parts.  Keep the threads and results in an
+            // array for future reference when writing
+            for (int i = 0; i < threadsNeeded; i++) {
+                final LogParserThread logParserThread = new LogParserThread(
+                        logParserReader, parsingRulesArray, compiledPatterns,
+                        threadCounter);
+                runners.add(logParserThread);
+                execSvc.execute(logParserThread);
+                threadCounter++;
+            }
+
+            // Wait for all threads to finish before sequentially writing the
+            // outcome
+            execSvc.shutdown();
+            execSvc.awaitTermination(3600, TimeUnit.SECONDS);
+
+            // Sort the threads in the order of the log parts they read
+            // It could be that thread #1 read log part #2 and thread #2 read log
+            // part #1
+
+            final int runnersSize = runners.size();
+            LogParserThread[] sortedRunners = new LogParserThread[runnersSize];
+            for (LogParserThread logParserThread : runners) {
+                final LogParserLogPart logPart = logParserThread.getLogPart();
+                if (logPart != null) {
+                    final int logPartNum = logPart.getLogPartNum();
+                    sortedRunners[logPartNum] = logParserThread;
+                }
+            }
+
+            final HashMap<String, String> result = new HashMap<>();
+            HashMap<String, String> moreLineStatusMatches;
+            for (int i = 0; i < runnersSize; i++) {
+                final LogParserThread logParserThread = sortedRunners[i];
+                if (logParserThread != null) {
+                    moreLineStatusMatches = getLineStatusMatches(
+                            logParserThread.getLineStatuses(), i);
+                    result.putAll(moreLineStatusMatches);
+                }
+            }
+            return result;
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HashMap<String, String> getLineStatusMatches(
+            final String[] statuses, final int logPart) {
+        final HashMap<String, String> result = new HashMap<>();
+        String status;
+        int line_num;
+        final int linesPerThread = LogParserUtils.getLinesPerThread();
+        for (int i = 0; i < statuses.length; i++) {
+            status = statuses[i];
+            line_num = i + logPart * linesPerThread;
+            result.put(String.valueOf(line_num), status);
+        }
+        return result;
+    }
+}

--- a/src/main/java/hudson/plugins/logparser/ClassicParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/ClassicParsingStrategy.java
@@ -9,6 +9,21 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+/**
+ * This was the only available {@link ParsingStrategy} in 2.3.0 and earlier.
+ * <p>
+ * For each build, this strategy will:
+ * <ol>
+ *     <li>Stream the log file to count lines via {@link LogParserUtils#countLines(String)}</li>
+ *     <li>Create an {@link ExecutorService} via {@link Executors#newCachedThreadPool()}</li>
+ *     <li>Determine number of {@link LogParserThread} tasks from lines / ({@link LogParserUtils#getLinesPerThread()} + 1)</li>
+ *     <li>Submit and wait for all tasks to finish</li>
+ *     <li>Aggregate lines into status from each task</li>
+ * </ol>
+ *
+ * @since 2.4.0
+ * @see StreamParsingStrategy
+ */
 class ClassicParsingStrategy implements ParsingStrategy {
     @Override
     public HashMap<String, String> parse(ParsingInput input) {

--- a/src/main/java/hudson/plugins/logparser/LineToStatus.java
+++ b/src/main/java/hudson/plugins/logparser/LineToStatus.java
@@ -1,0 +1,38 @@
+package hudson.plugins.logparser;
+
+import hudson.console.ConsoleNote;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class LineToStatus implements UnaryOperator<String> {
+    private final List<ParsingRulePattern> patterns;
+
+    LineToStatus(List<ParsingRulePattern> patterns) {
+        this.patterns = patterns;
+    }
+
+    @Override
+    public String apply(String s) {
+        // For now, strip out ConsoleNote(s) before parsing.
+        // Notes are injected into log lines, and can break start-of-line
+        // patterns, and include html. Will likely need alternative way to
+        // handle in the future.
+        String line = ConsoleNote.removeNotes(s);
+        for (ParsingRulePattern parsingRulePattern : patterns) {
+            String rule = parsingRulePattern.getRule();
+            if (LogParserUtils.skipParsingRule(rule)) {
+                continue;
+            }
+            Pattern pattern = parsingRulePattern.getPattern();
+            Matcher matcher = pattern.matcher(line);
+            if (matcher.find()) {
+                String status = rule.split("\\s")[0];
+                return LogParserUtils.standardizeStatus(status);
+            }
+        }
+        return LogParserConsts.NONE;
+    }
+}

--- a/src/main/java/hudson/plugins/logparser/LineToStatus.java
+++ b/src/main/java/hudson/plugins/logparser/LineToStatus.java
@@ -7,6 +7,11 @@ import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Extracted from {@link LogParserThread} so the same implementation could be
+ * used in different {@link ParsingStrategy} implementations.
+ * @since 2.4.0
+ */
 class LineToStatus implements UnaryOperator<String> {
     private final List<ParsingRulePattern> patterns;
 

--- a/src/main/java/hudson/plugins/logparser/LogParserStatusComputer.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserStatusComputer.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 
 public class LogParserStatusComputer extends MasterToSlaveCallable<HashMap<String, String>, RuntimeException> {
 
-    private static final long serialVersionUID = -4474356311889262212L;
+    private static final long serialVersionUID = -6025098995519544527L;
     final private String[] parsingRulesArray;
     final private Pattern[] compiledPatterns;
     private final InputStream remoteLog;
@@ -65,7 +65,8 @@ public class LogParserStatusComputer extends MasterToSlaveCallable<HashMap<Strin
         tempFilePath.copyFrom(log);
 
         logger.log(Level.INFO, "Local temp file:" + tempFileLocation);
-        ParsingStrategy strategy = new ClassicParsingStrategy();
+        ParsingStrategyLocator locator = ParsingStrategyLocator.create();
+        ParsingStrategy strategy = locator.get();
 
         try (final BufferedReader reader = new BufferedReader(new InputStreamReader(tempFilePath.read()))) {
             ParsingInput input = new ParsingInput(reader, tempFileLocation, parsingRulesArray, compiledPatterns);

--- a/src/main/java/hudson/plugins/logparser/LogParserStatusComputer.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserStatusComputer.java
@@ -1,7 +1,6 @@
 package hudson.plugins.logparser;
 
 import hudson.FilePath;
-import hudson.remoting.VirtualChannel;
 import hudson.remoting.RemoteInputStream;
 import jenkins.security.MasterToSlaveCallable;
 
@@ -10,18 +9,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 public class LogParserStatusComputer extends MasterToSlaveCallable<HashMap<String, String>, RuntimeException> {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -4474356311889262212L;
     final private String[] parsingRulesArray;
     final private Pattern[] compiledPatterns;
     private final InputStream remoteLog;
@@ -70,82 +65,16 @@ public class LogParserStatusComputer extends MasterToSlaveCallable<HashMap<Strin
         tempFilePath.copyFrom(log);
 
         logger.log(Level.INFO, "Local temp file:" + tempFileLocation);
+        ParsingStrategy strategy = new ClassicParsingStrategy();
 
         try (final BufferedReader reader = new BufferedReader(new InputStreamReader(tempFilePath.read()))) {
-            int threadCounter = 0;
-
-            final ArrayList<LogParserThread> runners = new ArrayList<>();
-            final LogParserReader logParserReader = new LogParserReader(reader);
-
-            //ExecutorService execSvc = Executors.newFixedThreadPool(
-            //    LogParserUtils.getNumThreads() );
-            final ExecutorService execSvc = Executors.newCachedThreadPool();
-            int linesInLog = LogParserUtils.countLines(tempFileLocation);
-            final int threadsNeeded = linesInLog
-                    / LogParserUtils.getLinesPerThread() + 1;
-
-            // Read and parse the log parts.  Keep the threads and results in an
-            // array for future reference when writing
-            for (int i = 0; i < threadsNeeded; i++) {
-                //logger.log(Level.INFO,"LogParserParser: Open thread #"+threadCounter);
-                final LogParserThread logParserThread = new LogParserThread(
-                        logParserReader, parsingRulesArray, compiledPatterns,
-                        threadCounter);
-                //logParserThread.start();
-                runners.add(logParserThread);
-                execSvc.execute(logParserThread);
-                threadCounter++;
-            }
-
-            // Wait for all threads to finish before sequentially writing the
-            // outcome
-            execSvc.shutdown();
-            execSvc.awaitTermination(3600, TimeUnit.SECONDS);
-
-            // Sort the threads in the order of the log parts they read
-            // It could be that thread #1 read log part #2 and thread #2 read log
-            // part #1
-
-            final int runnersSize = runners.size();
-            LogParserThread[] sortedRunners = new LogParserThread[runnersSize];
-            for (LogParserThread logParserThread : runners) {
-                final LogParserLogPart logPart = logParserThread.getLogPart();
-                if (logPart != null) {
-                    final int logPartNum = logPart.getLogPartNum();
-                    sortedRunners[logPartNum] = logParserThread;
-                }
-            }
-
-            final HashMap<String, String> result = new HashMap<>();
-            HashMap<String, String> moreLineStatusMatches;
-            for (int i = 0; i < runnersSize; i++) {
-                final LogParserThread logParserThread = sortedRunners[i];
-                if (logParserThread != null) {
-                    moreLineStatusMatches = getLineStatusMatches(
-                            logParserThread.getLineStatuses(), i);
-                    result.putAll(moreLineStatusMatches);
-                }
-            }
-            return result;
+            ParsingInput input = new ParsingInput(reader, tempFileLocation, parsingRulesArray, compiledPatterns);
+            return strategy.parse(input);
         } finally {
             // Delete temp file
             tempFilePath.delete();
         }
         // SLAVE PART END
-    }
-
-    private HashMap<String, String> getLineStatusMatches(
-            final String[] statuses, final int logPart) {
-        final HashMap<String, String> result = new HashMap<>();
-        String status;
-        int line_num;
-        final int linesPerThread = LogParserUtils.getLinesPerThread();
-        for (int i = 0; i < statuses.length; i++) {
-            status = statuses[i];
-            line_num = i + logPart * linesPerThread;
-            result.put(String.valueOf(line_num), status);
-        }
-        return result;
     }
 
 }

--- a/src/main/java/hudson/plugins/logparser/ParsingInput.java
+++ b/src/main/java/hudson/plugins/logparser/ParsingInput.java
@@ -1,0 +1,34 @@
+package hudson.plugins.logparser;
+
+import java.io.BufferedReader;
+import java.util.regex.Pattern;
+
+class ParsingInput {
+    private final BufferedReader reader;
+    private final String logPath;
+    private final String[] parsingRulesArray;
+    private final Pattern[] compiledPatterns;
+
+    ParsingInput(BufferedReader reader, String logPath, String[] parsingRulesArray, Pattern[] compiledPatterns) {
+        this.reader = reader;
+        this.logPath = logPath;
+        this.parsingRulesArray = parsingRulesArray;
+        this.compiledPatterns = compiledPatterns;
+    }
+
+    public BufferedReader getReader() {
+        return reader;
+    }
+
+    public String getLogPath() {
+        return logPath;
+    }
+
+    public String[] getParsingRulesArray() {
+        return parsingRulesArray;
+    }
+
+    public Pattern[] getCompiledPatterns() {
+        return compiledPatterns;
+    }
+}

--- a/src/main/java/hudson/plugins/logparser/ParsingRulePattern.java
+++ b/src/main/java/hudson/plugins/logparser/ParsingRulePattern.java
@@ -1,0 +1,44 @@
+package hudson.plugins.logparser;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.regex.Pattern;
+
+class ParsingRulePattern {
+    private final String rule;
+    private final Pattern pattern;
+
+    ParsingRulePattern(String rule, Pattern pattern) {
+        this.rule = rule;
+        this.pattern = pattern;
+    }
+
+    public String getRule() {
+        return rule;
+    }
+
+    public Pattern getPattern() {
+        return pattern;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ParsingRulePattern that = (ParsingRulePattern) o;
+        return Objects.equals(rule, that.rule) && Objects.equals(pattern, that.pattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rule, pattern);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ParsingRulePattern.class.getSimpleName() + "[", "]")
+                .add("rule='" + rule + "'")
+                .add("pattern=" + pattern)
+                .toString();
+    }
+}

--- a/src/main/java/hudson/plugins/logparser/ParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/ParsingStrategy.java
@@ -1,0 +1,7 @@
+package hudson.plugins.logparser;
+
+import java.util.HashMap;
+
+interface ParsingStrategy {
+    HashMap<String, String> parse(ParsingInput input);
+}

--- a/src/main/java/hudson/plugins/logparser/ParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/ParsingStrategy.java
@@ -2,6 +2,12 @@ package hudson.plugins.logparser;
 
 import java.util.HashMap;
 
+/**
+ * Extracted from {@link LogParserStatusComputer} to support additional parsing implementations.
+ * @see ClassicParsingStrategy
+ * @see StreamParsingStrategy
+ * @since 2.4.0
+ */
 interface ParsingStrategy {
     HashMap<String, String> parse(ParsingInput input);
 }

--- a/src/main/java/hudson/plugins/logparser/ParsingStrategyLocator.java
+++ b/src/main/java/hudson/plugins/logparser/ParsingStrategyLocator.java
@@ -1,0 +1,54 @@
+package hudson.plugins.logparser;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * Finds the desired {@link ParsingStrategy} by reading the system property {@code hudson.plugins.logparser.ParsingStrategy}.
+ * <p>
+ * The default strategy is {@link ClassicParsingStrategy}, which was the only available strategy through v2.3.0.
+ * This class logs the strategy selected at INFO level.
+ * <p>
+ * An invalid parameter is logged at WARNING and falls back to {@link ClassicParsingStrategy}.
+ *
+ * @since 2.4.0
+ */
+class ParsingStrategyLocator {
+    private static final String SYSTEM_PROPERTY = ParsingStrategy.class.getName();
+    private static final String CLASSIC = ClassicParsingStrategy.class.getName();
+    private static final String STREAM = StreamParsingStrategy.class.getName();
+    private static final Logger LOGGER = Logger.getLogger(ParsingStrategyLocator.class.getName());
+    private final Map<String, String> systemProperties;
+
+    ParsingStrategyLocator(Map<String, String> systemProperties) {
+        this.systemProperties = systemProperties;
+    }
+
+    static ParsingStrategyLocator create() {
+        Map<String, String> typedProperties = new HashMap<>();
+        Properties properties = System.getProperties();
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            typedProperties.put(entry.getKey().toString(), entry.getValue().toString());
+        }
+        return new ParsingStrategyLocator(typedProperties);
+    }
+
+    ParsingStrategy get() {
+        String strategy = systemProperties.get(SYSTEM_PROPERTY);
+
+        if (STREAM.equals(strategy)) {
+            LOGGER.info("Using " + STREAM + " as requested by system property " + SYSTEM_PROPERTY);
+            return new StreamParsingStrategy();
+        }
+        if (strategy == null) {
+            LOGGER.info("Defaulting to " + CLASSIC);
+        } else if (CLASSIC.equals(strategy)) {
+            LOGGER.info("Using " + CLASSIC + " as requested by system property " + SYSTEM_PROPERTY);
+        } else {
+            LOGGER.warning("Defaulting to " + CLASSIC + " because system property " + SYSTEM_PROPERTY + " was set to invalid strategy " + strategy);
+        }
+        return new ClassicParsingStrategy();
+    }
+}

--- a/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
@@ -1,0 +1,31 @@
+package hudson.plugins.logparser;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class StreamParsingStrategy implements ParsingStrategy {
+    @Override
+    public HashMap<String, String> parse(ParsingInput input) {
+        String[] parsingRulesArray = input.getParsingRulesArray();
+        Pattern[] compiledPatterns = input.getCompiledPatterns();
+        List<ParsingRulePattern> parsingRulePatterns = new LinkedList<>();
+        for (int i = 0; i < parsingRulesArray.length; i++) {
+            String rule = parsingRulesArray[i];
+            Pattern pattern = compiledPatterns[i];
+            parsingRulePatterns.add(new ParsingRulePattern(rule, pattern));
+        }
+        LineToStatus toStatus = new LineToStatus(parsingRulePatterns);
+        try (Stream<String> lines = input.getReader().lines()) {
+            List<String> statusByLine = lines.map(toStatus).collect(Collectors.toList());
+            final HashMap<String, String> result = new HashMap<>();
+            for (int i = 0; i < statusByLine.size(); i++) {
+                result.put(Integer.toString(i), statusByLine.get(i));
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
@@ -1,5 +1,6 @@
 package hudson.plugins.logparser;
 
+import java.io.BufferedReader;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -7,6 +8,18 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * This strategy relies on {@link BufferedReader#lines()}.
+ * <p>
+ * For each build, this strategy will:
+ * <ul>
+ *     <li>Lazily stream each line</li>
+ *     <li>Map it to a status via {@link LineToStatus}</li>
+ *     <li>Collect to a map of line number to status</li>
+ * </ul>
+ * @since 2.4.0
+ * @see ClassicParsingStrategy
+ */
 class StreamParsingStrategy implements ParsingStrategy {
     @Override
     public HashMap<String, String> parse(ParsingInput input) {

--- a/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
@@ -36,7 +36,10 @@ class StreamParsingStrategy implements ParsingStrategy {
             List<String> statusByLine = lines.map(toStatus).collect(Collectors.toList());
             final HashMap<String, String> result = new HashMap<>();
             for (int i = 0; i < statusByLine.size(); i++) {
-                result.put(Integer.toString(i), statusByLine.get(i));
+                String status = statusByLine.get(i);
+                if (!LogParserConsts.NONE.equals(status)) {
+                    result.put(Integer.toString(i), status);
+                }
             }
             return result;
         }

--- a/src/test/java/hudson/plugins/logparser/LineToStatusTest.java
+++ b/src/test/java/hudson/plugins/logparser/LineToStatusTest.java
@@ -1,0 +1,40 @@
+package hudson.plugins.logparser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LineToStatusTest {
+    private LineToStatus toStatus;
+
+    @Before
+    public void setUp() {
+        toStatus = new LineToStatus(Arrays.asList(
+                new ParsingRulePattern("my-rule", Pattern.compile("abc")),
+                new ParsingRulePattern("my-second-rule", Pattern.compile("bc")),
+                new ParsingRulePattern("#my-commented-rule", Pattern.compile("xyz"))
+        ));
+    }
+
+    @Test
+    public void shouldHandleEmpty() {
+        String actual = toStatus.apply("");
+        assertThat(actual).isEqualTo(LogParserConsts.NONE);
+    }
+
+    @Test
+    public void shouldSkipCommentedRule() {
+        String actual = toStatus.apply("xyz");
+        assertThat(actual).isEqualTo(LogParserConsts.NONE);
+    }
+
+    @Test
+    public void shouldFindOnlyFirstMatchingRule() {
+        String actual = toStatus.apply("abc");
+        assertThat(actual).isEqualTo("my-rule");
+    }
+}

--- a/src/test/java/hudson/plugins/logparser/ParsingStrategyLocatorTest.java
+++ b/src/test/java/hudson/plugins/logparser/ParsingStrategyLocatorTest.java
@@ -1,0 +1,43 @@
+package hudson.plugins.logparser;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParsingStrategyLocatorTest {
+
+    @Test
+    public void shouldDefaultToClassic() {
+        Map<String, String> systemProperties = new HashMap<>();
+        ParsingStrategyLocator locator = new ParsingStrategyLocator(systemProperties);
+
+        ParsingStrategy actual = locator.get();
+
+        assertThat(actual).isInstanceOf(ClassicParsingStrategy.class);
+    }
+
+    @Test
+    public void shouldAllowOverridingToStream() {
+        Map<String, String> systemProperties = new HashMap<>();
+        systemProperties.put(ParsingStrategy.class.getName(), StreamParsingStrategy.class.getName());
+        ParsingStrategyLocator locator = new ParsingStrategyLocator(systemProperties);
+
+        ParsingStrategy actual = locator.get();
+
+        assertThat(actual).isInstanceOf(StreamParsingStrategy.class);
+    }
+
+    @Test
+    public void shouldFallbackToClassic() {
+        Map<String, String> systemProperties = new HashMap<>();
+        systemProperties.put(ParsingStrategy.class.getName(), "does.not.match");
+        ParsingStrategyLocator locator = new ParsingStrategyLocator(systemProperties);
+
+        ParsingStrategy actual = locator.get();
+
+        assertThat(actual).isInstanceOf(ClassicParsingStrategy.class);
+    }
+}


### PR DESCRIPTION
This implementation is currently opt-in by setting the system property `hudson.plugins.logparser.ParsingStrategy` to `hudson.plugins.logparser.StreamParsingStrategy` on agents, but it'd be simpler to replace the current strategy. 

The new strategy relies on Java 8 features and improves throughput with less code. I'm happy to make that change, but thought it'd be worth discussing first.

## :memo: Description

We have a job using this plugin that intermittently hangs. I have been able to reproduce the scenario by creating a job that logs many lines, creating an `OutOfMemory` error on the agent. A new strategy is included here that allows the plugin to parse builds with more logs than the current approach.

Parsing time is a function of the number of lines in the file and the number of rules. To test this, I defined one rule and ran it on a job that created a set number of lines. 10% of the lines matched the rule. I expect 100 rules run against 100 lines would scale similarly to 10 rules run on 1,000 lines or one rule on 10,000 lines.

| Line-Rules | 2.3.0 (average seconds over 10 runs) | `StreamParsingStrategy` |
| ------------------|---------------------------------------------------|-----------------------------------|
|  100               | 0 | 0|
| 1,000 | 0 | 0 |
| 10,000 | 0 | 0 |
| 100,000 | 0 | 0 |
| 1,000,000 | 5 | 3.1 |
| 10,000,000 | 75.4 | 31.9 |
| 20,000,000 | Failed (OOM) | 66.3 |
| 50,000,000 | Failed (OOM) | 220 |

![2022-10-29-log-parsing-strategies](https://user-images.githubusercontent.com/230004/198866638-2a0c9723-7fc1-4ca2-8ca6-4b09ecc47746.png)

I'm using the already-existing [log statement in `LogParserParser`](https://github.com/jenkinsci/log-parser-plugin/blob/develop/src/main/java/hudson/plugins/logparser/LogParserParser.java#L371) to get this data. For small log files, both are under a second.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I extracted the current code into a `ClassicParsingStrategy` and introduced a new `StreamParsingStrategy`. The new classes have unit tests that verify behavior.

For testing large logs, I deployed Jenkins 2.361.2 on an Azure Standard D2s v3 (2 vcpus, 8 GiB memory) and an agent with one executor on another Standard D2s v3. I installed v2.3.0 from the update center to gather the baseline data. I built the plugin locally at this commit, uploaded, and set the system property for the comparison data. 

I created a job that would log out 10 lines on a loop, and a rules file with one rule.
<details>
<summary>build script</summary>
<pre>
echo "warn /warning/" > rules.txt

set +x
for i in $(seq 0 10)
do
  echo "> Task :javadocJar $i"
  echo "> Task :sourcesJar $i"
  echo "> Task :assemble $i"
  echo "> Task :codenarcMain $i"
  echo "> Task :codenarcTest $i"
  echo "> Task :compileTestKotlin NO-SOURCE $i"
  echo "> Task :pluginUnderTestMetadata $i"
  echo "> Task :compileTestJava NO-SOURCE $i"
  echo "> Task :javadoc $i"
  echo "/home/runner/work/gradle-jpi-plugin/gradle-jpi-plugin/src/main/java/shaded/hudson/util/VersionNumber.java:551: warning: no @param for idx $i"
done
</pre>
</details>

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
