### PR TITLE
Only copy the log to java.io.tmpdir in the ClassicParsingStrategy

### DIFF
--- a/src/main/java/hudson/plugins/logparser/ClassicParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/ClassicParsingStrategy.java
@@ -52,7 +52,7 @@ class ClassicParsingStrategy implements ParsingStrategy {
             tempFilePath.copyFrom(input.getLog());
 
             logger.log(Level.INFO, "Local temp file:" + tempFileLocation);
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(tempFilePath.read()))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(tempFilePath.read(), input.getCharset()))) {
                 String[] parsingRulesArray = input.getParsingRulesArray();
                 Pattern[] compiledPatterns = input.getCompiledPatterns();
                 int threadCounter = 0;

--- a/src/main/java/hudson/plugins/logparser/ClassicParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/ClassicParsingStrategy.java
@@ -1,12 +1,18 @@
 package hudson.plugins.logparser;
 
+import hudson.FilePath;
+
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /**
@@ -14,7 +20,8 @@ import java.util.regex.Pattern;
  * <p>
  * For each build, this strategy will:
  * <ol>
- *     <li>Stream the log file to count lines via {@link LogParserUtils#countLines(String)}</li>
+ *     <li>Copy the log into {@code java.io.tmpdir}</li>
+ *     <li>Stream the copied log file to count lines via {@link LogParserUtils#countLines(String)}</li>
  *     <li>Create an {@link ExecutorService} via {@link Executors#newCachedThreadPool()}</li>
  *     <li>Determine number of {@link LogParserThread} tasks from lines / ({@link LogParserUtils#getLinesPerThread()} + 1)</li>
  *     <li>Submit and wait for all tasks to finish</li>
@@ -27,64 +34,88 @@ import java.util.regex.Pattern;
 class ClassicParsingStrategy implements ParsingStrategy {
     @Override
     public HashMap<String, String> parse(ParsingInput input) {
-        BufferedReader reader = input.getReader();
-        String tempFileLocation = input.getLogPath();
-        String[] parsingRulesArray = input.getParsingRulesArray();
-        Pattern[] compiledPatterns = input.getCompiledPatterns();
-        int threadCounter = 0;
+        final Logger logger = Logger.getLogger(this.getClass().getName());
 
-        final ArrayList<LogParserThread> runners = new ArrayList<>();
-        final LogParserReader logParserReader = new LogParserReader(reader);
+        // Copy remote file to temp local location
+        String tempDir = System.getProperty("java.io.tmpdir");
+        if (!tempDir.endsWith(File.separator)) {
+            final StringBuffer tempDirBuffer = new StringBuffer(tempDir);
+            tempDirBuffer.append(File.separator);
+            tempDir = tempDirBuffer.toString();
+        }
+
+        final String tempFileLocation = tempDir + "log-parser_" + input.getSignature();
+        final File tempFile = new File(tempFileLocation);
+        final FilePath tempFilePath = new FilePath(tempFile);
 
         try {
-            final ExecutorService execSvc = Executors.newCachedThreadPool();
-            int linesInLog = LogParserUtils.countLines(tempFileLocation);
-            final int threadsNeeded = linesInLog
-                    / LogParserUtils.getLinesPerThread() + 1;
+            tempFilePath.copyFrom(input.getLog());
 
-            // Read and parse the log parts.  Keep the threads and results in an
-            // array for future reference when writing
-            for (int i = 0; i < threadsNeeded; i++) {
-                final LogParserThread logParserThread = new LogParserThread(
-                        logParserReader, parsingRulesArray, compiledPatterns,
-                        threadCounter);
-                runners.add(logParserThread);
-                execSvc.execute(logParserThread);
-                threadCounter++;
-            }
+            logger.log(Level.INFO, "Local temp file:" + tempFileLocation);
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(tempFilePath.read()))) {
+                String[] parsingRulesArray = input.getParsingRulesArray();
+                Pattern[] compiledPatterns = input.getCompiledPatterns();
+                int threadCounter = 0;
 
-            // Wait for all threads to finish before sequentially writing the
-            // outcome
-            execSvc.shutdown();
-            execSvc.awaitTermination(3600, TimeUnit.SECONDS);
+                final ArrayList<LogParserThread> runners = new ArrayList<>();
+                final LogParserReader logParserReader = new LogParserReader(reader);
 
-            // Sort the threads in the order of the log parts they read
-            // It could be that thread #1 read log part #2 and thread #2 read log
-            // part #1
+                final ExecutorService execSvc = Executors.newCachedThreadPool();
+                int linesInLog = LogParserUtils.countLines(tempFileLocation);
+                final int threadsNeeded = linesInLog
+                        / LogParserUtils.getLinesPerThread() + 1;
 
-            final int runnersSize = runners.size();
-            LogParserThread[] sortedRunners = new LogParserThread[runnersSize];
-            for (LogParserThread logParserThread : runners) {
-                final LogParserLogPart logPart = logParserThread.getLogPart();
-                if (logPart != null) {
-                    final int logPartNum = logPart.getLogPartNum();
-                    sortedRunners[logPartNum] = logParserThread;
+                // Read and parse the log parts.  Keep the threads and results in an
+                // array for future reference when writing
+                for (int i = 0; i < threadsNeeded; i++) {
+                    final LogParserThread logParserThread = new LogParserThread(
+                            logParserReader, parsingRulesArray, compiledPatterns,
+                            threadCounter);
+                    runners.add(logParserThread);
+                    execSvc.execute(logParserThread);
+                    threadCounter++;
                 }
-            }
 
-            final HashMap<String, String> result = new HashMap<>();
-            HashMap<String, String> moreLineStatusMatches;
-            for (int i = 0; i < runnersSize; i++) {
-                final LogParserThread logParserThread = sortedRunners[i];
-                if (logParserThread != null) {
-                    moreLineStatusMatches = getLineStatusMatches(
-                            logParserThread.getLineStatuses(), i);
-                    result.putAll(moreLineStatusMatches);
+                // Wait for all threads to finish before sequentially writing the
+                // outcome
+                execSvc.shutdown();
+                execSvc.awaitTermination(3600, TimeUnit.SECONDS);
+
+                // Sort the threads in the order of the log parts they read
+                // It could be that thread #1 read log part #2 and thread #2 read log
+                // part #1
+
+                final int runnersSize = runners.size();
+                LogParserThread[] sortedRunners = new LogParserThread[runnersSize];
+                for (LogParserThread logParserThread : runners) {
+                    final LogParserLogPart logPart = logParserThread.getLogPart();
+                    if (logPart != null) {
+                        final int logPartNum = logPart.getLogPartNum();
+                        sortedRunners[logPartNum] = logParserThread;
+                    }
                 }
+
+                final HashMap<String, String> result = new HashMap<>();
+                HashMap<String, String> moreLineStatusMatches;
+                for (int i = 0; i < runnersSize; i++) {
+                    final LogParserThread logParserThread = sortedRunners[i];
+                    if (logParserThread != null) {
+                        moreLineStatusMatches = getLineStatusMatches(
+                                logParserThread.getLineStatuses(), i);
+                        result.putAll(moreLineStatusMatches);
+                    }
+                }
+                return result;
             }
-            return result;
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
+        } finally {
+            // Delete temp file
+            try {
+                tempFilePath.delete();
+            } catch (IOException | InterruptedException e) {
+                logger.log(Level.WARNING, "Failed to delete " + tempFilePath, e);
+            }
         }
     }
 

--- a/src/main/java/hudson/plugins/logparser/LogParserParser.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserParser.java
@@ -12,6 +12,7 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -342,13 +343,14 @@ public class LogParserParser {
                 + build.getNumber();
         logger.log(Level.INFO, "LogParserParser: Start parsing : " + signature);
         final Calendar calendarStart = Calendar.getInstance();
+        Charset charset = build.getCharset();
 
         final HashMap<String, String> lineStatusMatches = channel.call(
-                new LogParserStatusComputer(log, parsingRulesArray, compiledPatterns, signature));
+                new LogParserStatusComputer(log, parsingRulesArray, compiledPatterns, signature, charset));
 
         // Read log file from start - line by line and apply the statuses as
         // found by the threads.
-        try (final InputStreamReader streamReader = new InputStreamReader(build.getLogInputStream(), build.getCharset());
+        try (final InputStreamReader streamReader = new InputStreamReader(build.getLogInputStream(), charset);
              final BufferedReader reader = new BufferedReader(streamReader)) {
             String line;
             String status;

--- a/src/main/java/hudson/plugins/logparser/LogParserStatusComputer.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserStatusComputer.java
@@ -1,22 +1,16 @@
 package hudson.plugins.logparser;
 
-import hudson.FilePath;
 import hudson.remoting.RemoteInputStream;
 import jenkins.security.MasterToSlaveCallable;
 
-import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.HashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 public class LogParserStatusComputer extends MasterToSlaveCallable<HashMap<String, String>, RuntimeException> {
 
-    private static final long serialVersionUID = -6025098995519544527L;
+    private static final long serialVersionUID = 8404353581893986125L;
     final private String[] parsingRulesArray;
     final private Pattern[] compiledPatterns;
     private final InputStream remoteLog;
@@ -48,33 +42,11 @@ public class LogParserStatusComputer extends MasterToSlaveCallable<HashMap<Strin
             final InputStream log,
             final String signature) throws IOException, InterruptedException {
         // SLAVE PART START
-
-        final Logger logger = Logger.getLogger(this.getClass().getName());
-
-        // Copy remote file to temp local location
-        String tempDir = System.getProperty("java.io.tmpdir");
-        if (!tempDir.endsWith(File.separator)) {
-            final StringBuffer tempDirBuffer = new StringBuffer(tempDir);
-            tempDirBuffer.append(File.separator);
-            tempDir = tempDirBuffer.toString();
-        }
-
-        final String tempFileLocation = tempDir + "log-parser_" + signature;
-        final File tempFile = new File(tempFileLocation);
-        final FilePath tempFilePath = new FilePath(tempFile);
-        tempFilePath.copyFrom(log);
-
-        logger.log(Level.INFO, "Local temp file:" + tempFileLocation);
         ParsingStrategyLocator locator = ParsingStrategyLocator.create();
         ParsingStrategy strategy = locator.get();
 
-        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(tempFilePath.read()))) {
-            ParsingInput input = new ParsingInput(reader, tempFileLocation, parsingRulesArray, compiledPatterns);
-            return strategy.parse(input);
-        } finally {
-            // Delete temp file
-            tempFilePath.delete();
-        }
+        ParsingInput input = new ParsingInput(parsingRulesArray, compiledPatterns, log, signature);
+        return strategy.parse(input);
         // SLAVE PART END
     }
 

--- a/src/main/java/hudson/plugins/logparser/LogParserStatusComputer.java
+++ b/src/main/java/hudson/plugins/logparser/LogParserStatusComputer.java
@@ -5,30 +5,53 @@ import jenkins.security.MasterToSlaveCallable;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.regex.Pattern;
 
 public class LogParserStatusComputer extends MasterToSlaveCallable<HashMap<String, String>, RuntimeException> {
 
-    private static final long serialVersionUID = 8404353581893986125L;
+    private static final long serialVersionUID = 646211554890510833L;
     final private String[] parsingRulesArray;
     final private Pattern[] compiledPatterns;
     private final InputStream remoteLog;
     private final String signature;
+    private final String charsetName;
 
     public LogParserStatusComputer(
-            final InputStream log, final String[] parsingRulesArray,
+            final InputStream log,
+            final String[] parsingRulesArray,
             final Pattern[] compiledPatterns,
-            final String signature) throws IOException, InterruptedException {
+            final String signature,
+            final Charset charset) {
         this.parsingRulesArray = parsingRulesArray;
         this.compiledPatterns = compiledPatterns;
         this.remoteLog = new RemoteInputStream(log, RemoteInputStream.Flag.GREEDY);
         this.signature = signature;
+        this.charsetName = charset.name();
+    }
+
+    /**
+     * Prefer the other constructor that allows for passing in the {@link Charset}.
+     * This constructor relies on the default charset.
+     * @param log
+     * @param parsingRulesArray
+     * @param compiledPatterns
+     * @param signature
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Deprecated
+    public LogParserStatusComputer(
+            final InputStream log, final String[] parsingRulesArray,
+            final Pattern[] compiledPatterns,
+            final String signature) throws IOException, InterruptedException {
+        this(log, parsingRulesArray, compiledPatterns, signature, Charset.defaultCharset());
     }
 
     public HashMap<String, String> call() {
         try {
-            return computeStatusMatches(remoteLog, signature);
+            return computeStatusMatches(remoteLog, signature, charsetName);
             // rethrow any exception here to report why the
             // parsing failed
         } catch (InterruptedException e) {
@@ -40,12 +63,13 @@ public class LogParserStatusComputer extends MasterToSlaveCallable<HashMap<Strin
 
     private HashMap<String, String> computeStatusMatches(
             final InputStream log,
-            final String signature) throws IOException, InterruptedException {
+            final String signature,
+            final String charsetName) throws IOException, InterruptedException {
         // SLAVE PART START
         ParsingStrategyLocator locator = ParsingStrategyLocator.create();
         ParsingStrategy strategy = locator.get();
 
-        ParsingInput input = new ParsingInput(parsingRulesArray, compiledPatterns, log, signature);
+        ParsingInput input = new ParsingInput(parsingRulesArray, compiledPatterns, log, signature, charsetName);
         return strategy.parse(input);
         // SLAVE PART END
     }

--- a/src/main/java/hudson/plugins/logparser/ParsingInput.java
+++ b/src/main/java/hudson/plugins/logparser/ParsingInput.java
@@ -1,27 +1,19 @@
 package hudson.plugins.logparser;
 
-import java.io.BufferedReader;
+import java.io.InputStream;
 import java.util.regex.Pattern;
 
 class ParsingInput {
-    private final BufferedReader reader;
-    private final String logPath;
     private final String[] parsingRulesArray;
     private final Pattern[] compiledPatterns;
+    private final InputStream log;
+    private final String signature;
 
-    ParsingInput(BufferedReader reader, String logPath, String[] parsingRulesArray, Pattern[] compiledPatterns) {
-        this.reader = reader;
-        this.logPath = logPath;
+    ParsingInput(String[] parsingRulesArray, Pattern[] compiledPatterns, InputStream log, String signature) {
         this.parsingRulesArray = parsingRulesArray;
         this.compiledPatterns = compiledPatterns;
-    }
-
-    public BufferedReader getReader() {
-        return reader;
-    }
-
-    public String getLogPath() {
-        return logPath;
+        this.log = log;
+        this.signature = signature;
     }
 
     public String[] getParsingRulesArray() {
@@ -30,5 +22,13 @@ class ParsingInput {
 
     public Pattern[] getCompiledPatterns() {
         return compiledPatterns;
+    }
+
+    public InputStream getLog() {
+        return log;
+    }
+
+    public String getSignature() {
+        return signature;
     }
 }

--- a/src/main/java/hudson/plugins/logparser/ParsingInput.java
+++ b/src/main/java/hudson/plugins/logparser/ParsingInput.java
@@ -1,6 +1,7 @@
 package hudson.plugins.logparser;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.regex.Pattern;
 
 class ParsingInput {
@@ -8,12 +9,14 @@ class ParsingInput {
     private final Pattern[] compiledPatterns;
     private final InputStream log;
     private final String signature;
+    private final String charsetName;
 
-    ParsingInput(String[] parsingRulesArray, Pattern[] compiledPatterns, InputStream log, String signature) {
+    ParsingInput(String[] parsingRulesArray, Pattern[] compiledPatterns, InputStream log, String signature, String charsetName) {
         this.parsingRulesArray = parsingRulesArray;
         this.compiledPatterns = compiledPatterns;
         this.log = log;
         this.signature = signature;
+        this.charsetName = charsetName;
     }
 
     public String[] getParsingRulesArray() {
@@ -30,5 +33,9 @@ class ParsingInput {
 
     public String getSignature() {
         return signature;
+    }
+
+    public Charset getCharset() {
+        return Charset.forName(charsetName);
     }
 }

--- a/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
@@ -1,6 +1,8 @@
 package hudson.plugins.logparser;
 
 import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,7 +34,8 @@ class StreamParsingStrategy implements ParsingStrategy {
             parsingRulePatterns.add(new ParsingRulePattern(rule, pattern));
         }
         LineToStatus toStatus = new LineToStatus(parsingRulePatterns);
-        try (Stream<String> lines = input.getReader().lines()) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input.getLog()));
+             Stream<String> lines = reader.lines()) {
             List<String> statusByLine = lines.map(toStatus).collect(Collectors.toList());
             final HashMap<String, String> result = new HashMap<>();
             for (int i = 0; i < statusByLine.size(); i++) {
@@ -42,6 +45,8 @@ class StreamParsingStrategy implements ParsingStrategy {
                 }
             }
             return result;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
+++ b/src/main/java/hudson/plugins/logparser/StreamParsingStrategy.java
@@ -34,7 +34,7 @@ class StreamParsingStrategy implements ParsingStrategy {
             parsingRulePatterns.add(new ParsingRulePattern(rule, pattern));
         }
         LineToStatus toStatus = new LineToStatus(parsingRulePatterns);
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input.getLog()));
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input.getLog(), input.getCharset()));
              Stream<String> lines = reader.lines()) {
             List<String> statusByLine = lines.map(toStatus).collect(Collectors.toList());
             final HashMap<String, String> result = new HashMap<>();


### PR DESCRIPTION
## :memo: Description

This change makes copying the build's log to a temp location a part of the `ClassicParsingStrategy`, allowing the `StreamParsingStrategy` to skip this step.

I noticed that the new `StreamParsingStrategy` (introduced in #40) only reads the stream once and doesn't need to copy to a temp location. We have a case where agents are hanging on lots of IO.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Avoids copying file

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I'm running this version on my Jenkins controller successfully. Existing tests pass.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
