### PR TITLE
Rebaseline Jenkins to 2.375.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
-def configurations = [
-        [ platform: "linux", jdk: "8", jenkins: null ],
-        //[ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ]
-]
-buildPlugin(configurations: configurations, useContainerAgent: true)
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
+  [ platform: 'linux', jdk: '17' ],
+])
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.49</version>
+        <version>4.67</version>
         <relativePath />
     </parent>
 
@@ -20,7 +20,7 @@
     <properties>
         <!-- TODO: remove once FindBugs issues are fixed -->
         <spotbugs.failOnError>false</spotbugs.failOnError>
-        <jenkins.version>2.332.1</jenkins.version>
+        <jenkins.version>2.375.4</jenkins.version>
         <!-- Maven Plugins -->
         <workflow-jenkins-plugin.version>2.5</workflow-jenkins-plugin.version>
         <maven-release-plugin.version>2.5.1</maven-release-plugin.version>
@@ -79,8 +79,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.332.x</artifactId>
-                <version>1654.vcb_69d035fa_20</version>
+                <artifactId>bom-2.375.x</artifactId>
+                <version>2179.v0884e842b_859</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
2.375.4 is now the lowest [recommended version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions)

Use this link to re-run the recipe: https://app.moderne.io/recipes/builder/R1gnp