### PR TITLE
spotbugs: Handle null variable instead of catching NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.24.2</version>

--- a/src/test/java/hudson/plugins/logparser/LogParserPublisherTest.java
+++ b/src/test/java/hudson/plugins/logparser/LogParserPublisherTest.java
@@ -1,0 +1,55 @@
+package hudson.plugins.logparser;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Publisher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LogParserPublisherTest {
+    @Mock
+    private LogParserPublisher.DescriptorImpl descriptor;
+    @Mock
+    private Run<?, ?> run;
+    @Mock
+    private Launcher launcher;
+    @Mock
+    private TaskListener listener;
+    @Captor
+    private ArgumentCaptor<LogParserAction> actionCaptor;
+
+    @Test
+    void shouldSetFailedToParseErrorOnNullParsingRulesPath(@TempDir File workspace) throws IOException, InterruptedException {
+        LogParserPublisher publisher = new LogParserPublisher(false, null, null) {
+            @Override
+            public BuildStepDescriptor<Publisher> getDescriptor() {
+                return descriptor;
+            }
+        };
+
+        publisher.perform(run, new FilePath(workspace), launcher, listener);
+
+        verify(run).setResult(Result.ABORTED);
+        verify(run).addAction(actionCaptor.capture());
+
+        LogParserAction actual = actionCaptor.getValue();
+        assertThat(actual.getResult().getFailedToParseError()).isEqualTo(LogParserPublisher.NULL_PARSING_RULES);
+    }
+
+}


### PR DESCRIPTION
## :memo: Description

This fixes the `DCN_NULLPOINTER_EXCEPTION` SpotBugs error that is [failing recent builds](https://github.com/jenkinsci/log-parser-plugin/runs/14390609443). Instead of catching the NPE, the code now checks for a null filepath and retains all the same behavior.

I have updated the error message from `java.lang.NullPointerException` to `Path to global parsing rules is null`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

Introduced a new `LogParserPublisherTest` class that covers this behavior.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
