### PR TITLE
Modernize to Jenkins 2.387.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.67</version>
+        <version>4.73</version>
         <relativePath />
     </parent>
 
@@ -20,7 +20,7 @@
     <properties>
         <!-- TODO: remove once FindBugs issues are fixed -->
         <spotbugs.failOnError>false</spotbugs.failOnError>
-        <jenkins.version>2.375.4</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
         <!-- Maven Plugins -->
         <workflow-jenkins-plugin.version>2.5</workflow-jenkins-plugin.version>
         <maven-release-plugin.version>2.5.1</maven-release-plugin.version>
@@ -79,8 +79,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.375.x</artifactId>
-                <version>2179.v0884e842b_859</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2446.v2e9fd3b_d8c81</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -148,11 +148,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>symbol-annotation</artifactId>
-            <scope>compile</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling and move this plugin to the [current recommended](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) Jenkins baseline version. This is also the lowest version of the plugins bom that is issuing new releases.

## Testing done
Ran `mvn clean verify`.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePlugin