### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: 'linux', jdk: '11' ],
-  [ platform: 'windows', jdk: '11' ],
-  [ platform: 'linux', jdk: '17' ],
+  [ platform: 'linux', jdk: 21 ],
+  [ platform: 'windows', jdk: 17 ],
 ])
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.73</version>
+        <version>4.74</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.387.x</artifactId>
-                <version>2446.v2e9fd3b_d8c81</version>
+                <version>2496.vddfca_753db_80</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -99,8 +99,27 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-aggregator</artifactId>
-            <version>${workflow-jenkins-plugin.version}</version>
+            <artifactId>workflow-cps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -123,25 +142,7 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>3.1.2</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <!-- Conflict with the current core, ignore -->
-                    <groupId>org.apache.ant</groupId>
-                    <artifactId>ant</artifactId>
-                </exclusion>
-                <exclusion>
-                    <!-- Conflict with the current core, ignore -->
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <!-- Conflict with the current core, ignore -->
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     </build>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/log-parser-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/log-parser-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/log-parser-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/log-parser-plugin</url>
         <tag>HEAD</tag>


### PR DESCRIPTION
## :memo: Description

Test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Replace workflow-aggregator with individual plugins

Plugin BOM provides versions for the individual plugins and does not provide a version for workflow-aggregator.

Remove exclusions that are no longer required

Use https:// instead of git:// in SCM URL.  GitHub no longer supports git:// protocol

Supersedes or includes the following pull requests:

* #86
* #83
* #79
* #76

### :dart: Relevant issues

[JENKINS-71800](https://issues.jenkins.io/browse/JENKINS-71800) Java 21 support - phase 1

### :gem: Type of change

- [x] Chore (changes are purely internal to the plugin, reduce future maintenance)

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Automated tests pass with Java 21 on Linux

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
