### PR TITLE
ci: use Temurin with setup-java v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
                 uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
                 with:
                     java-version: ${{ matrix.java }}
-                    distribution: "adopt"
+                    distribution: "temurin"
 
             -   name: Build with Maven
                 run: ./mvnw --batch-mode clean install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             -   name: Set up JDK
                 uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
                 with:
-                    distribution: 'adopt'
+                    distribution: 'temurin'
                     java-version: 25
                     cache: 'maven'
 


### PR DESCRIPTION
## :memo: Description

This companion repair for #258 replaces the removed setup-java v6 `adopt` distribution with its documented HotSpot successor, `temurin`, in both the build matrix and release workflow. Java versions, caching, and Renovate's pinned action commit remain unchanged.

The current bot head fails all four GitHub build lanes before Maven starts with `No supported distribution was found for input adopt`.

### :dart: Relevant issues

- #258

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :vertical_traffic_light: How Has This Been Tested?

- [x] JDK 21: `./mvnw --batch-mode --no-transfer-progress clean install pmd:check` — 27 tests, 0 failures/errors, 1 skip; SpotBugs, Enforcer, HPI assembly, and PMD passed
- [x] JDK 25: same clean command — 27 tests, 0 failures/errors, 1 skip; SpotBugs, Enforcer, HPI assembly, and PMD passed
- [x] all workflow YAML files parsed successfully
- [x] `git diff --check`

## :checkered_flag: Checklist

- [x] My change follows the style guidelines of this project
- [x] I have performed a self-review of the complete diff
- [x] New and existing unit tests pass locally with my changes

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
